### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/166/581/421166581.geojson
+++ b/data/421/166/581/421166581.geojson
@@ -158,6 +158,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008695,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"870fa3363ded6b0ffef47f00ae561c44",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":421166581,
-    "wof:lastmodified":1566584452,
+    "wof:lastmodified":1582351936,
     "wof:name":"Putumayo",
     "wof:parent_id":85670977,
     "wof:placetype":"county",

--- a/data/421/167/777/421167777.geojson
+++ b/data/421/167/777/421167777.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008742,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"272af9692fcb610b1349c90d6bfbd7ea",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":421167777,
-    "wof:lastmodified":1566584463,
+    "wof:lastmodified":1582351937,
     "wof:name":"Samborondon",
     "wof:parent_id":421189217,
     "wof:placetype":"localadmin",

--- a/data/421/167/781/421167781.geojson
+++ b/data/421/167/781/421167781.geojson
@@ -66,6 +66,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008743,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b8b6ff19a9c1b46b4578fe68ae355baa",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":421167781,
-    "wof:lastmodified":1566584463,
+    "wof:lastmodified":1582351937,
     "wof:name":"Celica",
     "wof:parent_id":421195603,
     "wof:placetype":"localadmin",

--- a/data/421/168/511/421168511.geojson
+++ b/data/421/168/511/421168511.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008767,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"325403a334ae19431f9d69ae128ba1d9",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421168511,
-    "wof:lastmodified":1566584451,
+    "wof:lastmodified":1582351936,
     "wof:name":"La Mana",
     "wof:parent_id":421178141,
     "wof:placetype":"localadmin",

--- a/data/421/168/623/421168623.geojson
+++ b/data/421/168/623/421168623.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008771,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"84dbd4b34edb3e85ddaaa788760ad371",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421168623,
-    "wof:lastmodified":1566584452,
+    "wof:lastmodified":1582351936,
     "wof:name":"Rumi\u00f1ahui",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/169/109/421169109.geojson
+++ b/data/421/169/109/421169109.geojson
@@ -592,6 +592,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008795,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e9b1a7c2fd2186d8029694f748c455a3",
     "wof:hierarchy":[
         {
@@ -603,7 +606,7 @@
         }
     ],
     "wof:id":421169109,
-    "wof:lastmodified":1566584465,
+    "wof:lastmodified":1582351937,
     "wof:name":"Quito",
     "wof:parent_id":421188131,
     "wof:placetype":"localadmin",

--- a/data/421/169/113/421169113.geojson
+++ b/data/421/169/113/421169113.geojson
@@ -158,6 +158,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008795,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e46e2c0730309a8b4d18c48e47bb1bb7",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
         }
     ],
     "wof:id":421169113,
-    "wof:lastmodified":1566584466,
+    "wof:lastmodified":1582351937,
     "wof:name":"Jipijapa",
     "wof:parent_id":1108569923,
     "wof:placetype":"localadmin",

--- a/data/421/169/313/421169313.geojson
+++ b/data/421/169/313/421169313.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008804,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7b1caf6c1bbcee393acb071feeb5f387",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421169313,
-    "wof:lastmodified":1566584464,
+    "wof:lastmodified":1582351937,
     "wof:name":"San Gabriel",
     "wof:parent_id":421197239,
     "wof:placetype":"localadmin",

--- a/data/421/169/315/421169315.geojson
+++ b/data/421/169/315/421169315.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008804,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7d7db5aae0e30ad0b8c5cde3534db5f2",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421169315,
-    "wof:lastmodified":1566584464,
+    "wof:lastmodified":1582351937,
     "wof:name":"San Jose de Quichinche",
     "wof:parent_id":421185493,
     "wof:placetype":"localadmin",

--- a/data/421/169/435/421169435.geojson
+++ b/data/421/169/435/421169435.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008810,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2e6f91108c23d9d4af57b38c2f01109",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421169435,
-    "wof:lastmodified":1566584466,
+    "wof:lastmodified":1582351937,
     "wof:name":"Muisne",
     "wof:parent_id":85670963,
     "wof:placetype":"county",

--- a/data/421/169/627/421169627.geojson
+++ b/data/421/169/627/421169627.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008817,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4935419a511b4122255de580e4f16695",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421169627,
-    "wof:lastmodified":1566584464,
+    "wof:lastmodified":1582351937,
     "wof:name":"Antonio Ante",
     "wof:parent_id":85670971,
     "wof:placetype":"county",

--- a/data/421/169/981/421169981.geojson
+++ b/data/421/169/981/421169981.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008832,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0ee78a13b8786b56c4e870bf5061ea91",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421169981,
-    "wof:lastmodified":1566584467,
+    "wof:lastmodified":1582351937,
     "wof:name":"Saquisili",
     "wof:parent_id":421184855,
     "wof:placetype":"localadmin",

--- a/data/421/169/983/421169983.geojson
+++ b/data/421/169/983/421169983.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008832,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"576c31c51f8509690b960bd21a77806f",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":421169983,
-    "wof:lastmodified":1566584464,
+    "wof:lastmodified":1582351937,
     "wof:name":"Sayausi",
     "wof:parent_id":421185495,
     "wof:placetype":"localadmin",

--- a/data/421/169/987/421169987.geojson
+++ b/data/421/169/987/421169987.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008832,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"db196c1bcf776718cdcde85a18838312",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421169987,
-    "wof:lastmodified":1566584466,
+    "wof:lastmodified":1582351937,
     "wof:name":"Urbina",
     "wof:parent_id":421204303,
     "wof:placetype":"localadmin",

--- a/data/421/170/053/421170053.geojson
+++ b/data/421/170/053/421170053.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008835,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"18e188e04442ebd3a95e1fd69e014649",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421170053,
-    "wof:lastmodified":1566584509,
+    "wof:lastmodified":1582351942,
     "wof:name":"Mindo",
     "wof:parent_id":421190531,
     "wof:placetype":"localadmin",

--- a/data/421/170/683/421170683.geojson
+++ b/data/421/170/683/421170683.geojson
@@ -80,6 +80,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008864,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bd1a6ee50eae1ee3ca4887f0e8a4510d",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":421170683,
-    "wof:lastmodified":1566584509,
+    "wof:lastmodified":1582351943,
     "wof:name":"Montalvo",
     "wof:parent_id":421185499,
     "wof:placetype":"localadmin",

--- a/data/421/170/685/421170685.geojson
+++ b/data/421/170/685/421170685.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008864,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"25c9c885c98c28d61df1d51f4d80e91d",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":421170685,
-    "wof:lastmodified":1566584509,
+    "wof:lastmodified":1582351943,
     "wof:name":"Nabon",
     "wof:parent_id":421186367,
     "wof:placetype":"localadmin",

--- a/data/421/170/689/421170689.geojson
+++ b/data/421/170/689/421170689.geojson
@@ -164,6 +164,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008864,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fe01987aad290044772a125f06fb9105",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":421170689,
-    "wof:lastmodified":1566584508,
+    "wof:lastmodified":1582351942,
     "wof:name":"Santa Clara",
     "wof:parent_id":1108572349,
     "wof:placetype":"localadmin",

--- a/data/421/170/967/421170967.geojson
+++ b/data/421/170/967/421170967.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008876,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9920febcb035a3367f37fe8054d39d03",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421170967,
-    "wof:lastmodified":1566584509,
+    "wof:lastmodified":1582351943,
     "wof:name":"Calpi",
     "wof:parent_id":421185337,
     "wof:placetype":"localadmin",

--- a/data/421/171/743/421171743.geojson
+++ b/data/421/171/743/421171743.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008905,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6dd774240a6918d697d8ca800d460124",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421171743,
-    "wof:lastmodified":1566584521,
+    "wof:lastmodified":1582351944,
     "wof:name":"Guaranda",
     "wof:parent_id":85670905,
     "wof:placetype":"county",

--- a/data/421/171/745/421171745.geojson
+++ b/data/421/171/745/421171745.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008905,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91f972ebcc1f70044ba4fa4df15a7336",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421171745,
-    "wof:lastmodified":1566584522,
+    "wof:lastmodified":1582351944,
     "wof:name":"Ibarra",
     "wof:parent_id":85670971,
     "wof:placetype":"county",

--- a/data/421/171/747/421171747.geojson
+++ b/data/421/171/747/421171747.geojson
@@ -170,6 +170,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008905,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b5d882f1d2a63e045cd90f0897b5b64",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         }
     ],
     "wof:id":421171747,
-    "wof:lastmodified":1566584520,
+    "wof:lastmodified":1582351944,
     "wof:name":"Gonzalo Pizarro",
     "wof:parent_id":85670977,
     "wof:placetype":"county",

--- a/data/421/171/751/421171751.geojson
+++ b/data/421/171/751/421171751.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008905,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13af4d11de08aa9e9c189745c592d035",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421171751,
-    "wof:lastmodified":1566584521,
+    "wof:lastmodified":1582351944,
     "wof:name":"Otavalo",
     "wof:parent_id":85670971,
     "wof:placetype":"county",

--- a/data/421/171/753/421171753.geojson
+++ b/data/421/171/753/421171753.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008905,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00a6677f69649c4fda8606289f964c5f",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421171753,
-    "wof:lastmodified":1566584520,
+    "wof:lastmodified":1582351944,
     "wof:name":"Pedro Moncayo",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/171/755/421171755.geojson
+++ b/data/421/171/755/421171755.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008905,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82a230c21086e36d88c53c4ba1acf834",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421171755,
-    "wof:lastmodified":1566584520,
+    "wof:lastmodified":1582351944,
     "wof:name":"Naranjal",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/171/759/421171759.geojson
+++ b/data/421/171/759/421171759.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008906,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a2a9b840fc376ca44b2fd439361a237",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421171759,
-    "wof:lastmodified":1566584521,
+    "wof:lastmodified":1582351944,
     "wof:name":"Salcedo",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/421/171/763/421171763.geojson
+++ b/data/421/171/763/421171763.geojson
@@ -212,6 +212,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008906,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d452fe84823800ce4edc3e918b3d9ac4",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":421171763,
-    "wof:lastmodified":1566584519,
+    "wof:lastmodified":1582351944,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85670963,
     "wof:placetype":"county",

--- a/data/421/171/769/421171769.geojson
+++ b/data/421/171/769/421171769.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008906,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b42785a0d743c257275aa356971bda6b",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421171769,
-    "wof:lastmodified":1566584521,
+    "wof:lastmodified":1582351944,
     "wof:name":"Puerto Lopez",
     "wof:parent_id":421176841,
     "wof:placetype":"localadmin",

--- a/data/421/172/287/421172287.geojson
+++ b/data/421/172/287/421172287.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008930,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"27f09fb8e84d14e15b2ce9026c0df2ae",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421172287,
-    "wof:lastmodified":1566584485,
+    "wof:lastmodified":1582351940,
     "wof:name":"Cariamanga",
     "wof:parent_id":1108568239,
     "wof:placetype":"localadmin",

--- a/data/421/172/549/421172549.geojson
+++ b/data/421/172/549/421172549.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008946,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7372b2778e122157c873675d283f4b8d",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421172549,
-    "wof:lastmodified":1566584488,
+    "wof:lastmodified":1582351940,
     "wof:name":"Rocafuerte",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/172/675/421172675.geojson
+++ b/data/421/172/675/421172675.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008951,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d9631613920430ccd4c258d1a32a275a",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421172675,
-    "wof:lastmodified":1566584485,
+    "wof:lastmodified":1582351940,
     "wof:name":"San Roque",
     "wof:parent_id":421195605,
     "wof:placetype":"localadmin",

--- a/data/421/173/233/421173233.geojson
+++ b/data/421/173/233/421173233.geojson
@@ -479,6 +479,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008975,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b2b3c81cd6600e6e2d4202d4a20947b",
     "wof:hierarchy":[
         {
@@ -490,7 +493,7 @@
         }
     ],
     "wof:id":421173233,
-    "wof:lastmodified":1566584476,
+    "wof:lastmodified":1582351938,
     "wof:name":"Quito",
     "wof:parent_id":421188131,
     "wof:placetype":"locality",

--- a/data/421/173/271/421173271.geojson
+++ b/data/421/173/271/421173271.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008976,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c185a71e8d8fc5b4cbe4fa7c1e10780f",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421173271,
-    "wof:lastmodified":1566584477,
+    "wof:lastmodified":1582351938,
     "wof:name":"Vinces",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/421/173/273/421173273.geojson
+++ b/data/421/173/273/421173273.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008977,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b26645cf17d1ce53b670dcce86b55b41",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421173273,
-    "wof:lastmodified":1566584475,
+    "wof:lastmodified":1582351938,
     "wof:name":"Chican",
     "wof:parent_id":421193503,
     "wof:placetype":"localadmin",

--- a/data/421/173/275/421173275.geojson
+++ b/data/421/173/275/421173275.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008977,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a08e463bb9db7bfce1bb69d8a5f28663",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":421173275,
-    "wof:lastmodified":1566584476,
+    "wof:lastmodified":1582351938,
     "wof:name":"Colonche",
     "wof:parent_id":1108572401,
     "wof:placetype":"localadmin",

--- a/data/421/173/277/421173277.geojson
+++ b/data/421/173/277/421173277.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008977,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b4ca4d61f9c3088e821c31e232cb6463",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421173277,
-    "wof:lastmodified":1566584477,
+    "wof:lastmodified":1582351938,
     "wof:name":"Guaranda",
     "wof:parent_id":421171743,
     "wof:placetype":"localadmin",

--- a/data/421/173/281/421173281.geojson
+++ b/data/421/173/281/421173281.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008977,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"77d5fb6b473d8dde567e18e029fe7259",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421173281,
-    "wof:lastmodified":1566584476,
+    "wof:lastmodified":1582351938,
     "wof:name":"Llano Chico",
     "wof:parent_id":421188131,
     "wof:placetype":"localadmin",

--- a/data/421/173/285/421173285.geojson
+++ b/data/421/173/285/421173285.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008977,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8dffc3a5bbed0f451085f4ea93836a38",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421173285,
-    "wof:lastmodified":1566584477,
+    "wof:lastmodified":1582351938,
     "wof:name":"Oton",
     "wof:parent_id":421197049,
     "wof:placetype":"localadmin",

--- a/data/421/173/287/421173287.geojson
+++ b/data/421/173/287/421173287.geojson
@@ -196,6 +196,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008977,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f5ae8650e0abf03bb9b346561170f4e9",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
         }
     ],
     "wof:id":421173287,
-    "wof:lastmodified":1566584475,
+    "wof:lastmodified":1582351938,
     "wof:name":"Palenque",
     "wof:parent_id":1108570915,
     "wof:placetype":"localadmin",

--- a/data/421/173/289/421173289.geojson
+++ b/data/421/173/289/421173289.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008977,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"84d35fce921bd79d4813e20edcc0670c",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421173289,
-    "wof:lastmodified":1566584476,
+    "wof:lastmodified":1582351938,
     "wof:name":"Sucua",
     "wof:parent_id":421193533,
     "wof:placetype":"localadmin",

--- a/data/421/173/293/421173293.geojson
+++ b/data/421/173/293/421173293.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459008977,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"23966435afe34d10576de10e7d0b4d20",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421173293,
-    "wof:lastmodified":1566584476,
+    "wof:lastmodified":1582351938,
     "wof:name":"Zambiza",
     "wof:parent_id":421188131,
     "wof:placetype":"localadmin",

--- a/data/421/173/925/421173925.geojson
+++ b/data/421/173/925/421173925.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009011,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5e6f3d4a76d53794b1752057b479db3",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421173925,
-    "wof:lastmodified":1566584477,
+    "wof:lastmodified":1582351938,
     "wof:name":"San Juan de Pastocalle",
     "wof:parent_id":421182157,
     "wof:placetype":"localadmin",

--- a/data/421/174/813/421174813.geojson
+++ b/data/421/174/813/421174813.geojson
@@ -218,6 +218,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009045,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"2399fa4e6d963b962584daab14afc040",
     "wof:hierarchy":[
         {
@@ -229,7 +232,7 @@
         }
     ],
     "wof:id":421174813,
-    "wof:lastmodified":1566584473,
+    "wof:lastmodified":1582351938,
     "wof:name":"Puerto Villamil",
     "wof:parent_id":1108569881,
     "wof:placetype":"locality",

--- a/data/421/175/411/421175411.geojson
+++ b/data/421/175/411/421175411.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8cd90fa9277b0d202e9d3c93fc0aaee",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421175411,
-    "wof:lastmodified":1566584494,
+    "wof:lastmodified":1582351941,
     "wof:name":"Manta",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/175/413/421175413.geojson
+++ b/data/421/175/413/421175413.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1040d31753f12f3f7a521700cfbeaf33",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421175413,
-    "wof:lastmodified":1566584492,
+    "wof:lastmodified":1582351940,
     "wof:name":"Mej\u00eda",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/175/415/421175415.geojson
+++ b/data/421/175/415/421175415.geojson
@@ -179,6 +179,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c5e20f7f49984acb1e180499c849a84b",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":421175415,
-    "wof:lastmodified":1566584493,
+    "wof:lastmodified":1582351940,
     "wof:name":"Mera",
     "wof:parent_id":85670949,
     "wof:placetype":"county",

--- a/data/421/175/419/421175419.geojson
+++ b/data/421/175/419/421175419.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e130a41c8d80784d677d74075a0c481f",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421175419,
-    "wof:lastmodified":1566584494,
+    "wof:lastmodified":1582351941,
     "wof:name":"Veinticuatro de Mayo",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/175/423/421175423.geojson
+++ b/data/421/175/423/421175423.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009067,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1affdf3e2c11e16fb8770c176f12412a",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421175423,
-    "wof:lastmodified":1566584493,
+    "wof:lastmodified":1582351940,
     "wof:name":"Guayaquil",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/176/719/421176719.geojson
+++ b/data/421/176/719/421176719.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009117,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"32e8a68aded237bda06a7bd4b96fb56a",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421176719,
-    "wof:lastmodified":1566584519,
+    "wof:lastmodified":1582351944,
     "wof:name":"Tumbaco",
     "wof:parent_id":421188131,
     "wof:placetype":"localadmin",

--- a/data/421/176/841/421176841.geojson
+++ b/data/421/176/841/421176841.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009121,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"15ec201c7171d59f468638a5971ba491",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421176841,
-    "wof:lastmodified":1566584519,
+    "wof:lastmodified":1582351944,
     "wof:name":"Puerto L\u00f3pez",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/177/409/421177409.geojson
+++ b/data/421/177/409/421177409.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009143,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f7dd27c9e2313c2fc89c47f24ee13ed6",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421177409,
-    "wof:lastmodified":1566584510,
+    "wof:lastmodified":1582351943,
     "wof:name":"Sidcay",
     "wof:parent_id":421185495,
     "wof:placetype":"localadmin",

--- a/data/421/177/637/421177637.geojson
+++ b/data/421/177/637/421177637.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009156,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"60f46df1ff9bc297ee26d90d180f9002",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421177637,
-    "wof:lastmodified":1566584511,
+    "wof:lastmodified":1582351943,
     "wof:name":"Lago Agrio",
     "wof:parent_id":85670977,
     "wof:placetype":"county",

--- a/data/421/177/945/421177945.geojson
+++ b/data/421/177/945/421177945.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009165,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39e24bec7f3293d8e03138b03fc2c598",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421177945,
-    "wof:lastmodified":1566584511,
+    "wof:lastmodified":1582351943,
     "wof:name":"Quiroga",
     "wof:parent_id":421185493,
     "wof:placetype":"localadmin",

--- a/data/421/178/137/421178137.geojson
+++ b/data/421/178/137/421178137.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009172,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f0420bc94054e1a89eca67c87c903ee0",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421178137,
-    "wof:lastmodified":1566584515,
+    "wof:lastmodified":1582351943,
     "wof:name":"Joya de los Sachas",
     "wof:parent_id":85670941,
     "wof:placetype":"county",

--- a/data/421/178/141/421178141.geojson
+++ b/data/421/178/141/421178141.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009172,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e81d04f2d74da41751c888038775f45",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421178141,
-    "wof:lastmodified":1566584516,
+    "wof:lastmodified":1582351944,
     "wof:name":"La Man\u00e1",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/421/179/215/421179215.geojson
+++ b/data/421/179/215/421179215.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009208,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b89fd19a5c1a4defa19a3bc532a686b",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421179215,
-    "wof:lastmodified":1566584514,
+    "wof:lastmodified":1582351943,
     "wof:name":"Chunchi",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/179/423/421179423.geojson
+++ b/data/421/179/423/421179423.geojson
@@ -198,6 +198,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009220,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea2bcbaffd807938f0c83ed32820a7d2",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":421179423,
-    "wof:lastmodified":1566584514,
+    "wof:lastmodified":1582351943,
     "wof:name":"Nueva Loja",
     "wof:parent_id":421177637,
     "wof:placetype":"localadmin",

--- a/data/421/179/425/421179425.geojson
+++ b/data/421/179/425/421179425.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009220,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"086ecc925432a753eb61b363656b439b",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421179425,
-    "wof:lastmodified":1566584514,
+    "wof:lastmodified":1582351943,
     "wof:name":"Gualaceo",
     "wof:parent_id":1108569603,
     "wof:placetype":"localadmin",

--- a/data/421/179/429/421179429.geojson
+++ b/data/421/179/429/421179429.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009220,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"753e9e4ff4ef7283b7ddb8b52530e68d",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":421179429,
-    "wof:lastmodified":1566584515,
+    "wof:lastmodified":1582351943,
     "wof:name":"Catarama",
     "wof:parent_id":1108573179,
     "wof:placetype":"localadmin",

--- a/data/421/179/431/421179431.geojson
+++ b/data/421/179/431/421179431.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009220,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2963c9608f693193becba82fb6452f79",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":421179431,
-    "wof:lastmodified":1566584514,
+    "wof:lastmodified":1582351943,
     "wof:name":"Calceta",
     "wof:parent_id":1108568121,
     "wof:placetype":"localadmin",

--- a/data/421/180/535/421180535.geojson
+++ b/data/421/180/535/421180535.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009262,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eba8bed74f17e19f2eb78fb59275ecdb",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421180535,
-    "wof:lastmodified":1566584473,
+    "wof:lastmodified":1582351938,
     "wof:name":"Espejo",
     "wof:parent_id":85670967,
     "wof:placetype":"county",

--- a/data/421/180/927/421180927.geojson
+++ b/data/421/180/927/421180927.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009276,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef80da0b1133974a4a82028c267ac0a1",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421180927,
-    "wof:lastmodified":1566584474,
+    "wof:lastmodified":1582351938,
     "wof:name":"Cotacachi",
     "wof:parent_id":421185493,
     "wof:placetype":"localadmin",

--- a/data/421/180/961/421180961.geojson
+++ b/data/421/180/961/421180961.geojson
@@ -85,6 +85,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009277,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a7ea93319140cc411637bd96604dd4b6",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421180961,
-    "wof:lastmodified":1566584474,
+    "wof:lastmodified":1582351938,
     "wof:name":"Pedernales",
     "wof:parent_id":1108571251,
     "wof:placetype":"localadmin",

--- a/data/421/181/315/421181315.geojson
+++ b/data/421/181/315/421181315.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009292,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fcd5f15c3a8a800be244b1ebbc6dc783",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421181315,
-    "wof:lastmodified":1566584491,
+    "wof:lastmodified":1582351940,
     "wof:name":"San Crist\u00f3bal",
     "wof:parent_id":421181765,
     "wof:placetype":"localadmin",

--- a/data/421/181/765/421181765.geojson
+++ b/data/421/181/765/421181765.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009306,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c1d4b6d8002e957b68422cd6a0c47e1",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421181765,
-    "wof:lastmodified":1566584490,
+    "wof:lastmodified":1582351940,
     "wof:name":"San Crist\u00f3bal",
     "wof:parent_id":85670899,
     "wof:placetype":"county",

--- a/data/421/182/157/421182157.geojson
+++ b/data/421/182/157/421182157.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009320,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"907c59bfc9a1ea810131e1e1d25916cd",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421182157,
-    "wof:lastmodified":1566584516,
+    "wof:lastmodified":1582351944,
     "wof:name":"Latacunga",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/421/182/159/421182159.geojson
+++ b/data/421/182/159/421182159.geojson
@@ -167,6 +167,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009320,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"641bb55bb9ef1ba3e837718ba2e985aa",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         }
     ],
     "wof:id":421182159,
-    "wof:lastmodified":1566584516,
+    "wof:lastmodified":1582351944,
     "wof:name":"Loja",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/421/182/449/421182449.geojson
+++ b/data/421/182/449/421182449.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009330,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"deb2208af3f0e743d253086c4fa5e149",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421182449,
-    "wof:lastmodified":1566584517,
+    "wof:lastmodified":1582351944,
     "wof:name":"Zamora",
     "wof:parent_id":85670895,
     "wof:placetype":"county",

--- a/data/421/183/023/421183023.geojson
+++ b/data/421/183/023/421183023.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009355,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f43cd9500c1f818a85be197c1eec65a",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421183023,
-    "wof:lastmodified":1566584511,
+    "wof:lastmodified":1582351943,
     "wof:name":"Bibli\u00e1n",
     "wof:parent_id":85670909,
     "wof:placetype":"county",

--- a/data/421/183/147/421183147.geojson
+++ b/data/421/183/147/421183147.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009359,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"50fb6c3f45524f9233baa97badc512a8",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421183147,
-    "wof:lastmodified":1566584513,
+    "wof:lastmodified":1582351943,
     "wof:name":"Aguarico",
     "wof:parent_id":85670941,
     "wof:placetype":"county",

--- a/data/421/183/153/421183153.geojson
+++ b/data/421/183/153/421183153.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009359,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cc21cfd1cc3866fcfe87f0b8c6ecc335",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421183153,
-    "wof:lastmodified":1566584513,
+    "wof:lastmodified":1582351943,
     "wof:name":"Jambeli",
     "wof:parent_id":1108572519,
     "wof:placetype":"localadmin",

--- a/data/421/183/189/421183189.geojson
+++ b/data/421/183/189/421183189.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009361,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4e627648bcee63d3374b0b00f75b9662",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421183189,
-    "wof:lastmodified":1566584513,
+    "wof:lastmodified":1582351943,
     "wof:name":"Pindilig",
     "wof:parent_id":421195039,
     "wof:placetype":"localadmin",

--- a/data/421/183/415/421183415.geojson
+++ b/data/421/183/415/421183415.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009368,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7ab6a619b61f2b513e0f7a6ef02a7f64",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421183415,
-    "wof:lastmodified":1566584512,
+    "wof:lastmodified":1582351943,
     "wof:name":"Villa La Union",
     "wof:parent_id":421194443,
     "wof:placetype":"localadmin",

--- a/data/421/183/469/421183469.geojson
+++ b/data/421/183/469/421183469.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009370,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5b186a37cdcac10e25fc119825867c3c",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421183469,
-    "wof:lastmodified":1566584513,
+    "wof:lastmodified":1582351943,
     "wof:name":"Loja",
     "wof:parent_id":421182159,
     "wof:placetype":"localadmin",

--- a/data/421/183/473/421183473.geojson
+++ b/data/421/183/473/421183473.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009370,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b7ee1ab20d756acf90b4bed6df0ef8af",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":421183473,
-    "wof:lastmodified":1566584513,
+    "wof:lastmodified":1582351943,
     "wof:name":"Zumbahua",
     "wof:parent_id":421185497,
     "wof:placetype":"localadmin",

--- a/data/421/183/483/421183483.geojson
+++ b/data/421/183/483/421183483.geojson
@@ -265,6 +265,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009371,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa1bf20933f5894ee15389c3bc97ac19",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
         }
     ],
     "wof:id":421183483,
-    "wof:lastmodified":1566584512,
+    "wof:lastmodified":1582351943,
     "wof:name":"Santa Cruz",
     "wof:parent_id":85670899,
     "wof:placetype":"county",

--- a/data/421/183/823/421183823.geojson
+++ b/data/421/183/823/421183823.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009388,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"64e1e40073ad019213e61a00340698ca",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421183823,
-    "wof:lastmodified":1566584513,
+    "wof:lastmodified":1582351943,
     "wof:name":"Ventanas",
     "wof:parent_id":1108573237,
     "wof:placetype":"localadmin",

--- a/data/421/183/825/421183825.geojson
+++ b/data/421/183/825/421183825.geojson
@@ -69,6 +69,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009388,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e797e0b4a1fd7360b2e791d4819d86b5",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":421183825,
-    "wof:lastmodified":1566584513,
+    "wof:lastmodified":1582351943,
     "wof:name":"Naranjal",
     "wof:parent_id":421171755,
     "wof:placetype":"localadmin",

--- a/data/421/183/941/421183941.geojson
+++ b/data/421/183/941/421183941.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009395,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb0b1206bae333f4ff7169a9d1f2859c",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421183941,
-    "wof:lastmodified":1566584512,
+    "wof:lastmodified":1582351943,
     "wof:name":"Chinchipe",
     "wof:parent_id":85670895,
     "wof:placetype":"county",

--- a/data/421/184/155/421184155.geojson
+++ b/data/421/184/155/421184155.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009402,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"404e2255b78389534df02cab45c0599d",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421184155,
-    "wof:lastmodified":1566584507,
+    "wof:lastmodified":1582351942,
     "wof:name":"San Lucas",
     "wof:parent_id":421182159,
     "wof:placetype":"localadmin",

--- a/data/421/184/203/421184203.geojson
+++ b/data/421/184/203/421184203.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009403,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4094afa5c1dc7a8aae06609208a7bbc0",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421184203,
-    "wof:lastmodified":1566584506,
+    "wof:lastmodified":1582351942,
     "wof:name":"Paj\u00e1n",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/184/411/421184411.geojson
+++ b/data/421/184/411/421184411.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009409,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac3be7b98d120ed3fe50070d82f39825",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421184411,
-    "wof:lastmodified":1566584507,
+    "wof:lastmodified":1582351942,
     "wof:name":"Penipe",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/184/413/421184413.geojson
+++ b/data/421/184/413/421184413.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009410,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3654df37fc3c8de151894e46019d390a",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421184413,
-    "wof:lastmodified":1566584505,
+    "wof:lastmodified":1582351942,
     "wof:name":"San Miguel de Urcuqu\u00ed",
     "wof:parent_id":85670971,
     "wof:placetype":"county",

--- a/data/421/184/517/421184517.geojson
+++ b/data/421/184/517/421184517.geojson
@@ -84,6 +84,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009413,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2cd38e3c02c9ee47701ae413dc18bf46",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":421184517,
-    "wof:lastmodified":1566584506,
+    "wof:lastmodified":1582351942,
     "wof:name":"Pedro Carbo",
     "wof:parent_id":1108571289,
     "wof:placetype":"localadmin",

--- a/data/421/184/627/421184627.geojson
+++ b/data/421/184/627/421184627.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009417,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"976679db199bfac1c5d025ffeda9502b",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421184627,
-    "wof:lastmodified":1566584506,
+    "wof:lastmodified":1582351942,
     "wof:name":"Saraguro",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/421/184/631/421184631.geojson
+++ b/data/421/184/631/421184631.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009417,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e69099c95eb0c59217f0b9723364ada4",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":421184631,
-    "wof:lastmodified":1566584508,
+    "wof:lastmodified":1582351942,
     "wof:name":"Huaquillas",
     "wof:parent_id":1108569819,
     "wof:placetype":"localadmin",

--- a/data/421/184/633/421184633.geojson
+++ b/data/421/184/633/421184633.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009417,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b03313f57a11e04000cec48624333d4f",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421184633,
-    "wof:lastmodified":1566584506,
+    "wof:lastmodified":1582351942,
     "wof:name":"Mera",
     "wof:parent_id":421175415,
     "wof:placetype":"localadmin",

--- a/data/421/184/733/421184733.geojson
+++ b/data/421/184/733/421184733.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009420,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7ddb53d90ea36ee57a20c24200a340c0",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421184733,
-    "wof:lastmodified":1566584507,
+    "wof:lastmodified":1582351942,
     "wof:name":"Zaruma",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/421/184/851/421184851.geojson
+++ b/data/421/184/851/421184851.geojson
@@ -182,6 +182,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009424,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca1e5e7395c175ae8d788dfa4809b18e",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
         }
     ],
     "wof:id":421184851,
-    "wof:lastmodified":1566584506,
+    "wof:lastmodified":1582351942,
     "wof:name":"Loreto",
     "wof:parent_id":85670941,
     "wof:placetype":"county",

--- a/data/421/184/855/421184855.geojson
+++ b/data/421/184/855/421184855.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009424,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bf67061ae63418bb6757f12b506c6e3",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421184855,
-    "wof:lastmodified":1566584508,
+    "wof:lastmodified":1582351942,
     "wof:name":"Saquisil\u00ed",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/421/184/865/421184865.geojson
+++ b/data/421/184/865/421184865.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009424,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a0c2c2a17ee37100c57f205ccf3f2ee1",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421184865,
-    "wof:lastmodified":1566584508,
+    "wof:lastmodified":1582351942,
     "wof:name":"Sigchos",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/421/184/959/421184959.geojson
+++ b/data/421/184/959/421184959.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009428,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f05add14664672ce10e1141b89a5f0eb",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421184959,
-    "wof:lastmodified":1566584507,
+    "wof:lastmodified":1582351942,
     "wof:name":"Abdon Calderon",
     "wof:parent_id":421189221,
     "wof:placetype":"localadmin",

--- a/data/421/185/029/421185029.geojson
+++ b/data/421/185/029/421185029.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009430,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d551be339fe6cf7c86c5f77c2b42ad98",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421185029,
-    "wof:lastmodified":1566584524,
+    "wof:lastmodified":1582351945,
     "wof:name":"La Joya de Los Sachas",
     "wof:parent_id":421178137,
     "wof:placetype":"localadmin",

--- a/data/421/185/075/421185075.geojson
+++ b/data/421/185/075/421185075.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009431,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"55a8f59f263d3cdf4449ebd341f53a2f",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421185075,
-    "wof:lastmodified":1566584524,
+    "wof:lastmodified":1582351945,
     "wof:name":"Ba\u00f1os",
     "wof:parent_id":421185495,
     "wof:placetype":"localadmin",

--- a/data/421/185/077/421185077.geojson
+++ b/data/421/185/077/421185077.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009431,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"622dc09f92ebb99b34d73cd64628c222",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421185077,
-    "wof:lastmodified":1566584522,
+    "wof:lastmodified":1582351944,
     "wof:name":"La Troncal",
     "wof:parent_id":421191239,
     "wof:placetype":"localadmin",

--- a/data/421/185/225/421185225.geojson
+++ b/data/421/185/225/421185225.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009436,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"63bfa1eaeb4a78756bbb0b6bb03b1c7e",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":421185225,
-    "wof:lastmodified":1566584524,
+    "wof:lastmodified":1582351945,
     "wof:name":"Zamora",
     "wof:parent_id":421182449,
     "wof:placetype":"localadmin",

--- a/data/421/185/337/421185337.geojson
+++ b/data/421/185/337/421185337.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009439,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"808d21437884dd9d35e9f4d38c1f5e1e",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421185337,
-    "wof:lastmodified":1566584522,
+    "wof:lastmodified":1582351944,
     "wof:name":"Riobamba",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/185/361/421185361.geojson
+++ b/data/421/185/361/421185361.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009441,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea33d7d4100fe6d08e0fa15815f06965",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421185361,
-    "wof:lastmodified":1566584524,
+    "wof:lastmodified":1582351945,
     "wof:name":"Salinas",
     "wof:parent_id":421171745,
     "wof:placetype":"localadmin",

--- a/data/421/185/491/421185491.geojson
+++ b/data/421/185/491/421185491.geojson
@@ -215,6 +215,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009444,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"df064d3d65a2df2756628782e7c4353b",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":421185491,
-    "wof:lastmodified":1566584523,
+    "wof:lastmodified":1582351945,
     "wof:name":"Orellana",
     "wof:parent_id":85670941,
     "wof:placetype":"county",

--- a/data/421/185/493/421185493.geojson
+++ b/data/421/185/493/421185493.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009445,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e6c1ed182c984e78e828097b699374ce",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421185493,
-    "wof:lastmodified":1566584524,
+    "wof:lastmodified":1582351945,
     "wof:name":"Cotacachi",
     "wof:parent_id":85670971,
     "wof:placetype":"county",

--- a/data/421/185/495/421185495.geojson
+++ b/data/421/185/495/421185495.geojson
@@ -229,6 +229,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009445,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7c242d39b03779592eb70afa5b4efaf",
     "wof:hierarchy":[
         {
@@ -239,7 +242,7 @@
         }
     ],
     "wof:id":421185495,
-    "wof:lastmodified":1566584525,
+    "wof:lastmodified":1582351945,
     "wof:name":"Cuenca",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/421/185/497/421185497.geojson
+++ b/data/421/185/497/421185497.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009445,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c631c58b634afea51a7c2ee14fc270c",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421185497,
-    "wof:lastmodified":1566584523,
+    "wof:lastmodified":1582351945,
     "wof:name":"Pujil\u00ed",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/421/185/499/421185499.geojson
+++ b/data/421/185/499/421185499.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009445,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69f2948e0eb8bdd8fc56d2aecdc40e26",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421185499,
-    "wof:lastmodified":1566584523,
+    "wof:lastmodified":1582351945,
     "wof:name":"Pastaza",
     "wof:parent_id":85670949,
     "wof:placetype":"county",

--- a/data/421/186/367/421186367.geojson
+++ b/data/421/186/367/421186367.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009478,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fdc7d57f08b30c7584eb23c36bcaec3e",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421186367,
-    "wof:lastmodified":1566584489,
+    "wof:lastmodified":1582351940,
     "wof:name":"Nab\u00f3n",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/421/186/441/421186441.geojson
+++ b/data/421/186/441/421186441.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009481,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e4407d7fb2d1dd659c809727cde1f93d",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421186441,
-    "wof:lastmodified":1566584488,
+    "wof:lastmodified":1582351940,
     "wof:name":"Salinas",
     "wof:parent_id":421171743,
     "wof:placetype":"localadmin",

--- a/data/421/188/121/421188121.geojson
+++ b/data/421/188/121/421188121.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009535,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e303a94cade15e6ea7a71f98cf1e7d7c",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421188121,
-    "wof:lastmodified":1566584484,
+    "wof:lastmodified":1582351939,
     "wof:name":"Chordeleg",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/421/188/123/421188123.geojson
+++ b/data/421/188/123/421188123.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009535,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"32dca1f92e66f87309f642ad88a745b3",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421188123,
-    "wof:lastmodified":1566584485,
+    "wof:lastmodified":1582351940,
     "wof:name":"Cuyabeno",
     "wof:parent_id":85670977,
     "wof:placetype":"county",

--- a/data/421/188/127/421188127.geojson
+++ b/data/421/188/127/421188127.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009535,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5723c141cc80e5ebd025e5e17cc4d29c",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421188127,
-    "wof:lastmodified":1566584483,
+    "wof:lastmodified":1582351939,
     "wof:name":"Playas",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/188/131/421188131.geojson
+++ b/data/421/188/131/421188131.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009535,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"40ccda9f308b9f3477d4ccd2914dda97",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421188131,
-    "wof:lastmodified":1566584484,
+    "wof:lastmodified":1582351939,
     "wof:name":"Quito",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/188/739/421188739.geojson
+++ b/data/421/188/739/421188739.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009577,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c3acb26694d62aa392d21fad0f27bef8",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421188739,
-    "wof:lastmodified":1566584483,
+    "wof:lastmodified":1582351939,
     "wof:name":"Daule",
     "wof:parent_id":421201111,
     "wof:placetype":"localadmin",

--- a/data/421/188/743/421188743.geojson
+++ b/data/421/188/743/421188743.geojson
@@ -80,6 +80,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009577,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7c560fb5e13d9bf894f1de1dab6f6a8d",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":421188743,
-    "wof:lastmodified":1566584484,
+    "wof:lastmodified":1582351940,
     "wof:name":"El Cisne",
     "wof:parent_id":421182159,
     "wof:placetype":"localadmin",

--- a/data/421/188/745/421188745.geojson
+++ b/data/421/188/745/421188745.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009577,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b1b6412876d246d5d1d21031c08e9c9b",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421188745,
-    "wof:lastmodified":1566584485,
+    "wof:lastmodified":1582351940,
     "wof:name":"El Tambo",
     "wof:parent_id":1108569245,
     "wof:placetype":"localadmin",

--- a/data/421/188/747/421188747.geojson
+++ b/data/421/188/747/421188747.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009577,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"262fb485de27f74337e037bc57b0e838",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421188747,
-    "wof:lastmodified":1566584483,
+    "wof:lastmodified":1582351939,
     "wof:name":"Jaramijo",
     "wof:parent_id":1108570471,
     "wof:placetype":"localadmin",

--- a/data/421/188/749/421188749.geojson
+++ b/data/421/188/749/421188749.geojson
@@ -231,6 +231,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009577,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bc8eca1294fd4c03636eecb1e4445c4b",
     "wof:hierarchy":[
         {
@@ -242,7 +245,7 @@
         }
     ],
     "wof:id":421188749,
-    "wof:lastmodified":1566584483,
+    "wof:lastmodified":1582351939,
     "wof:name":"Guano",
     "wof:parent_id":421201625,
     "wof:placetype":"localadmin",

--- a/data/421/188/751/421188751.geojson
+++ b/data/421/188/751/421188751.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009577,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae065c2ef4ede6050e5c3489dd2fe5d3",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":421188751,
-    "wof:lastmodified":1566584484,
+    "wof:lastmodified":1582351940,
     "wof:name":"Mira",
     "wof:parent_id":421203379,
     "wof:placetype":"localadmin",

--- a/data/421/188/753/421188753.geojson
+++ b/data/421/188/753/421188753.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009577,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3e2d2798521afd70ff4aa9275575d404",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421188753,
-    "wof:lastmodified":1566584483,
+    "wof:lastmodified":1582351939,
     "wof:name":"Pomona",
     "wof:parent_id":421185499,
     "wof:placetype":"localadmin",

--- a/data/421/188/761/421188761.geojson
+++ b/data/421/188/761/421188761.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009577,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd54cc879250bbf2c92520b2e17ffe7f",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":421188761,
-    "wof:lastmodified":1566584484,
+    "wof:lastmodified":1582351940,
     "wof:name":"Vuelta Larga",
     "wof:parent_id":1108569317,
     "wof:placetype":"localadmin",

--- a/data/421/188/915/421188915.geojson
+++ b/data/421/188/915/421188915.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009588,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3af05d789407621d4bf724ece44718e0",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421188915,
-    "wof:lastmodified":1566584483,
+    "wof:lastmodified":1582351939,
     "wof:name":"Cumbaya",
     "wof:parent_id":421188131,
     "wof:placetype":"localadmin",

--- a/data/421/188/917/421188917.geojson
+++ b/data/421/188/917/421188917.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009588,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ead3461674d1baf0bba8d8e3afdec743",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421188917,
-    "wof:lastmodified":1566584485,
+    "wof:lastmodified":1582351940,
     "wof:name":"Guamote",
     "wof:parent_id":421191235,
     "wof:placetype":"localadmin",

--- a/data/421/188/925/421188925.geojson
+++ b/data/421/188/925/421188925.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009588,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52d6139d64a8b808ff7bca81040fe587",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421188925,
-    "wof:lastmodified":1566584484,
+    "wof:lastmodified":1582351939,
     "wof:name":"Montecristi",
     "wof:parent_id":1108570471,
     "wof:placetype":"localadmin",

--- a/data/421/189/201/421189201.geojson
+++ b/data/421/189/201/421189201.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009613,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7bd0530841c9fbd0dd882d5bd3eee45c",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":421189201,
-    "wof:lastmodified":1566584482,
+    "wof:lastmodified":1582351939,
     "wof:name":"La Libertad",
     "wof:parent_id":85670979,
     "wof:placetype":"county",

--- a/data/421/189/211/421189211.geojson
+++ b/data/421/189/211/421189211.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009614,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"58c8fc87716153775b394bbd08e7d482",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421189211,
-    "wof:lastmodified":1566584478,
+    "wof:lastmodified":1582351938,
     "wof:name":"Chone",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/189/213/421189213.geojson
+++ b/data/421/189/213/421189213.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009614,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2eeb871af9e6b3b100f83c8f1fce3c1d",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421189213,
-    "wof:lastmodified":1566584481,
+    "wof:lastmodified":1582351939,
     "wof:name":"Portovelo",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/421/189/215/421189215.geojson
+++ b/data/421/189/215/421189215.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009614,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a51d098c28883685718e8df49b234c8d",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421189215,
-    "wof:lastmodified":1566584480,
+    "wof:lastmodified":1582351939,
     "wof:name":"Quevedo",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/421/189/217/421189217.geojson
+++ b/data/421/189/217/421189217.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009614,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"92ffe43a3edcfc58b8855275789c78ca",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421189217,
-    "wof:lastmodified":1566584479,
+    "wof:lastmodified":1582351938,
     "wof:name":"Samborond\u00f3n",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/189/221/421189221.geojson
+++ b/data/421/189/221/421189221.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009614,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"89775fe083090e5d840929688d695214",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421189221,
-    "wof:lastmodified":1566584479,
+    "wof:lastmodified":1582351938,
     "wof:name":"Santa Isabel",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/421/189/223/421189223.geojson
+++ b/data/421/189/223/421189223.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009614,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"132c13fde6f529445df983b4be742cf1",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421189223,
-    "wof:lastmodified":1566584480,
+    "wof:lastmodified":1582351939,
     "wof:name":"Portoviejo",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/189/225/421189225.geojson
+++ b/data/421/189/225/421189225.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009614,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f60a49474eccb94cda47a3ff8ab74ab4",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421189225,
-    "wof:lastmodified":1566584481,
+    "wof:lastmodified":1582351939,
     "wof:name":"Cayambe",
     "wof:parent_id":421197049,
     "wof:placetype":"localadmin",

--- a/data/421/189/231/421189231.geojson
+++ b/data/421/189/231/421189231.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009614,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"273853e0da9b9b0b30109c51385c3126",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189231,
-    "wof:lastmodified":1566584481,
+    "wof:lastmodified":1582351939,
     "wof:name":"Biblian",
     "wof:parent_id":421183023,
     "wof:placetype":"localadmin",

--- a/data/421/189/235/421189235.geojson
+++ b/data/421/189/235/421189235.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009614,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5854e53e620e4bb657b7a586ca30fdc4",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189235,
-    "wof:lastmodified":1566584480,
+    "wof:lastmodified":1582351939,
     "wof:name":"Chorocopte",
     "wof:parent_id":421195597,
     "wof:placetype":"localadmin",

--- a/data/421/189/237/421189237.geojson
+++ b/data/421/189/237/421189237.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009614,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ecece70cef2f35c91da3b0a602fade9e",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189237,
-    "wof:lastmodified":1566584482,
+    "wof:lastmodified":1582351939,
     "wof:name":"Cuyabeno",
     "wof:parent_id":421188123,
     "wof:placetype":"localadmin",

--- a/data/421/189/239/421189239.geojson
+++ b/data/421/189/239/421189239.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009614,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6b33360e42661b2d261c1483e8654283",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421189239,
-    "wof:lastmodified":1566584482,
+    "wof:lastmodified":1582351939,
     "wof:name":"La Libertad",
     "wof:parent_id":421203481,
     "wof:placetype":"localadmin",

--- a/data/421/189/241/421189241.geojson
+++ b/data/421/189/241/421189241.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009614,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2f1c3571820b08ad4cac782363e2eef",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189241,
-    "wof:lastmodified":1566584480,
+    "wof:lastmodified":1582351939,
     "wof:name":"Limoncocha",
     "wof:parent_id":1108572739,
     "wof:placetype":"localadmin",

--- a/data/421/189/243/421189243.geojson
+++ b/data/421/189/243/421189243.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bfeda64c4721be63e543d1077561aa25",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421189243,
-    "wof:lastmodified":1566584479,
+    "wof:lastmodified":1582351939,
     "wof:name":"Manta",
     "wof:parent_id":421175411,
     "wof:placetype":"localadmin",

--- a/data/421/189/247/421189247.geojson
+++ b/data/421/189/247/421189247.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fff583993e20a6e16dfab8bd8bee2c79",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421189247,
-    "wof:lastmodified":1566584480,
+    "wof:lastmodified":1582351939,
     "wof:name":"Otavalo",
     "wof:parent_id":421171751,
     "wof:placetype":"localadmin",

--- a/data/421/189/249/421189249.geojson
+++ b/data/421/189/249/421189249.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"807eeeb5a47f4e589740e052a45655ad",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":421189249,
-    "wof:lastmodified":1566584481,
+    "wof:lastmodified":1582351939,
     "wof:name":"Pomasqui",
     "wof:parent_id":421188131,
     "wof:placetype":"localadmin",

--- a/data/421/189/251/421189251.geojson
+++ b/data/421/189/251/421189251.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3852918b418a828fdbc23ccbb7f72bd9",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189251,
-    "wof:lastmodified":1566584480,
+    "wof:lastmodified":1582351939,
     "wof:name":"Plaza Gutierrez",
     "wof:parent_id":421171751,
     "wof:placetype":"localadmin",

--- a/data/421/189/253/421189253.geojson
+++ b/data/421/189/253/421189253.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b0f13d3739e07263ffe241d8cfb42287",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189253,
-    "wof:lastmodified":1566584481,
+    "wof:lastmodified":1582351939,
     "wof:name":"Pi\u00f1as",
     "wof:parent_id":421195605,
     "wof:placetype":"localadmin",

--- a/data/421/189/255/421189255.geojson
+++ b/data/421/189/255/421189255.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"afeb60e3e2e5d6d71aee317cfce9567c",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421189255,
-    "wof:lastmodified":1566584482,
+    "wof:lastmodified":1582351939,
     "wof:name":"Portoviejo",
     "wof:parent_id":421189223,
     "wof:placetype":"localadmin",

--- a/data/421/189/257/421189257.geojson
+++ b/data/421/189/257/421189257.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a8fa2a64c4c4c16a0fa5cc2d8d5d0022",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189257,
-    "wof:lastmodified":1566584479,
+    "wof:lastmodified":1582351939,
     "wof:name":"Puerto Fco. de Orellana",
     "wof:parent_id":421185491,
     "wof:placetype":"localadmin",

--- a/data/421/189/259/421189259.geojson
+++ b/data/421/189/259/421189259.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3e6f7f965cec9b5e26574f70688253fe",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189259,
-    "wof:lastmodified":1566584479,
+    "wof:lastmodified":1582351939,
     "wof:name":"Pujili",
     "wof:parent_id":421185497,
     "wof:placetype":"localadmin",

--- a/data/421/189/261/421189261.geojson
+++ b/data/421/189/261/421189261.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3975f91d01412ae21901caa3bbeafe4a",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189261,
-    "wof:lastmodified":1566584479,
+    "wof:lastmodified":1582351939,
     "wof:name":"San Miguel de Los Bancos",
     "wof:parent_id":421190531,
     "wof:placetype":"localadmin",

--- a/data/421/189/265/421189265.geojson
+++ b/data/421/189/265/421189265.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a1fb114c8f552fb3ee85e0a1d05525a8",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421189265,
-    "wof:lastmodified":1566584481,
+    "wof:lastmodified":1582351939,
     "wof:name":"Shell",
     "wof:parent_id":421175415,
     "wof:placetype":"localadmin",

--- a/data/421/189/507/421189507.geojson
+++ b/data/421/189/507/421189507.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009627,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"68edc25b16458b8a448c504b0754b59a",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189507,
-    "wof:lastmodified":1566584480,
+    "wof:lastmodified":1582351939,
     "wof:name":"San Bartolome",
     "wof:parent_id":421185495,
     "wof:placetype":"localadmin",

--- a/data/421/189/509/421189509.geojson
+++ b/data/421/189/509/421189509.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009627,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b47aa60564b42e571e1a63251f5c1b46",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421189509,
-    "wof:lastmodified":1566584480,
+    "wof:lastmodified":1582351939,
     "wof:name":"San Pablo",
     "wof:parent_id":421171751,
     "wof:placetype":"localadmin",

--- a/data/421/189/511/421189511.geojson
+++ b/data/421/189/511/421189511.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009627,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7a2f6b334862b2ed23090489f5df6725",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189511,
-    "wof:lastmodified":1566584480,
+    "wof:lastmodified":1582351939,
     "wof:name":"Teniente Hugo Ortiz",
     "wof:parent_id":421185499,
     "wof:placetype":"localadmin",

--- a/data/421/189/513/421189513.geojson
+++ b/data/421/189/513/421189513.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009627,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c7c2a853eb8a5c81244ab8aa78823a84",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189513,
-    "wof:lastmodified":1566584482,
+    "wof:lastmodified":1582351939,
     "wof:name":"San Andres",
     "wof:parent_id":421201625,
     "wof:placetype":"localadmin",

--- a/data/421/190/531/421190531.geojson
+++ b/data/421/190/531/421190531.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009660,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"604e9011c066a0d93e95a428160e6366",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421190531,
-    "wof:lastmodified":1566584499,
+    "wof:lastmodified":1582351941,
     "wof:name":"San Miguel de los Bancos",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/190/535/421190535.geojson
+++ b/data/421/190/535/421190535.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009660,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8e968e01c108b3a2dac844f336c31cf",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421190535,
-    "wof:lastmodified":1566584499,
+    "wof:lastmodified":1582351941,
     "wof:name":"Santo Domingo de los Colorados",
     "wof:parent_id":85670983,
     "wof:placetype":"county",

--- a/data/421/191/233/421191233.geojson
+++ b/data/421/191/233/421191233.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009685,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd8b045818df6f1e1765d7337ab0099c",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421191233,
-    "wof:lastmodified":1566584497,
+    "wof:lastmodified":1582351941,
     "wof:name":"Macar\u00e1",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/421/191/235/421191235.geojson
+++ b/data/421/191/235/421191235.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009685,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"830e98adbe66a5ff7b81e83c04d5df85",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421191235,
-    "wof:lastmodified":1566584497,
+    "wof:lastmodified":1582351941,
     "wof:name":"Guamote",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/191/239/421191239.geojson
+++ b/data/421/191/239/421191239.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009685,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"96bbcc7f57b0a63523d584f9762046bb",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421191239,
-    "wof:lastmodified":1566584499,
+    "wof:lastmodified":1582351941,
     "wof:name":"La Troncal",
     "wof:parent_id":85670909,
     "wof:placetype":"county",

--- a/data/421/191/241/421191241.geojson
+++ b/data/421/191/241/421191241.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009685,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"20b3c835c3694b42cb5973b48607cc77",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421191241,
-    "wof:lastmodified":1566584498,
+    "wof:lastmodified":1582351941,
     "wof:name":"Morona",
     "wof:parent_id":85670935,
     "wof:placetype":"county",

--- a/data/421/191/245/421191245.geojson
+++ b/data/421/191/245/421191245.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009685,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d64f9f0b95f7588410dec65854ae0be6",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421191245,
-    "wof:lastmodified":1566584496,
+    "wof:lastmodified":1582351941,
     "wof:name":"Milagro",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/191/247/421191247.geojson
+++ b/data/421/191/247/421191247.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009685,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9899537131d7872ff154551e80aef12c",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421191247,
-    "wof:lastmodified":1566584498,
+    "wof:lastmodified":1582351941,
     "wof:name":"Pasaje",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/421/191/251/421191251.geojson
+++ b/data/421/191/251/421191251.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009685,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0ec297c34154bd5141d5d5279c975b2d",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191251,
-    "wof:lastmodified":1566584497,
+    "wof:lastmodified":1582351941,
     "wof:name":"Aloag",
     "wof:parent_id":421175413,
     "wof:placetype":"localadmin",

--- a/data/421/191/255/421191255.geojson
+++ b/data/421/191/255/421191255.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009685,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3aa81ac3fb40b4e2c698660025bc7167",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":421191255,
-    "wof:lastmodified":1566584499,
+    "wof:lastmodified":1582351941,
     "wof:name":"Nono",
     "wof:parent_id":421188131,
     "wof:placetype":"localadmin",

--- a/data/421/191/483/421191483.geojson
+++ b/data/421/191/483/421191483.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009694,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6c2757c67028677e84ebd05ecf3bd157",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421191483,
-    "wof:lastmodified":1566584496,
+    "wof:lastmodified":1582351941,
     "wof:name":"Sabanilla",
     "wof:parent_id":421182449,
     "wof:placetype":"localadmin",

--- a/data/421/191/485/421191485.geojson
+++ b/data/421/191/485/421191485.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009694,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca7c746821953cf9e55f7487860f0ec3",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191485,
-    "wof:lastmodified":1566584496,
+    "wof:lastmodified":1582351941,
     "wof:name":"Sangolqui",
     "wof:parent_id":421168623,
     "wof:placetype":"localadmin",

--- a/data/421/191/487/421191487.geojson
+++ b/data/421/191/487/421191487.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009694,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c089d0e317657f59ee7c7f2fafdfe2e7",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421191487,
-    "wof:lastmodified":1566584498,
+    "wof:lastmodified":1582351941,
     "wof:name":"Santa Elena",
     "wof:parent_id":1108572401,
     "wof:placetype":"localadmin",

--- a/data/421/191/597/421191597.geojson
+++ b/data/421/191/597/421191597.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009698,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"403897e13b78eeda1d8612e3635e4c8f",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191597,
-    "wof:lastmodified":1566584498,
+    "wof:lastmodified":1582351941,
     "wof:name":"Gonzalez Suarez",
     "wof:parent_id":421171751,
     "wof:placetype":"localadmin",

--- a/data/421/192/905/421192905.geojson
+++ b/data/421/192/905/421192905.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009753,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"89d6cd8bcb5b848906fa99c9c8a400f9",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421192905,
-    "wof:lastmodified":1566584455,
+    "wof:lastmodified":1582351936,
     "wof:name":"Chambo",
     "wof:parent_id":421201227,
     "wof:placetype":"localadmin",

--- a/data/421/192/947/421192947.geojson
+++ b/data/421/192/947/421192947.geojson
@@ -260,6 +260,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009754,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7091c0a1e9b3d68cdd9270414292c6bc",
     "wof:hierarchy":[
         {
@@ -270,7 +273,7 @@
         }
     ],
     "wof:id":421192947,
-    "wof:lastmodified":1566584454,
+    "wof:lastmodified":1582351936,
     "wof:name":"Atahualpa",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/421/193/383/421193383.geojson
+++ b/data/421/193/383/421193383.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009769,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9167ea0f27954a007b7c860c09b17a68",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421193383,
-    "wof:lastmodified":1566584462,
+    "wof:lastmodified":1582351937,
     "wof:name":"Chugchillan",
     "wof:parent_id":421184865,
     "wof:placetype":"localadmin",

--- a/data/421/193/455/421193455.geojson
+++ b/data/421/193/455/421193455.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009772,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"456bad2ed36a3a5aa08d082ce668489b",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421193455,
-    "wof:lastmodified":1566584462,
+    "wof:lastmodified":1582351937,
     "wof:name":"Vilcabamba",
     "wof:parent_id":421182159,
     "wof:placetype":"localadmin",

--- a/data/421/193/503/421193503.geojson
+++ b/data/421/193/503/421193503.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009773,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0724fa36a110a914a2fd1e9c36ac7964",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421193503,
-    "wof:lastmodified":1566584461,
+    "wof:lastmodified":1582351937,
     "wof:name":"Paute",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/421/193/533/421193533.geojson
+++ b/data/421/193/533/421193533.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009774,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2c3087d1580b3faee8f84540a852fe64",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421193533,
-    "wof:lastmodified":1566584461,
+    "wof:lastmodified":1582351937,
     "wof:name":"Suc\u00faa",
     "wof:parent_id":85670935,
     "wof:placetype":"county",

--- a/data/421/194/443/421194443.geojson
+++ b/data/421/194/443/421194443.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5de8443dac45db202e42c6670456b37e",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421194443,
-    "wof:lastmodified":1566584460,
+    "wof:lastmodified":1582351937,
     "wof:name":"Colta",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/194/445/421194445.geojson
+++ b/data/421/194/445/421194445.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aab58f34bdeb38e2a83d1f0e353253d9",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421194445,
-    "wof:lastmodified":1566584461,
+    "wof:lastmodified":1582351937,
     "wof:name":"Santa Ana",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/194/929/421194929.geojson
+++ b/data/421/194/929/421194929.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009824,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0d62795077b6ae566c5d172bcbb422cf",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":421194929,
-    "wof:lastmodified":1566584461,
+    "wof:lastmodified":1582351937,
     "wof:name":"Las Nieves",
     "wof:parent_id":421186367,
     "wof:placetype":"localadmin",

--- a/data/421/194/931/421194931.geojson
+++ b/data/421/194/931/421194931.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009824,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f8475fe6f377bac3cf0b2a64cba1c005",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421194931,
-    "wof:lastmodified":1566584459,
+    "wof:lastmodified":1582351937,
     "wof:name":"Llacao",
     "wof:parent_id":421185495,
     "wof:placetype":"localadmin",

--- a/data/421/194/935/421194935.geojson
+++ b/data/421/194/935/421194935.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009825,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bac7a6b0a7f6cd60c6525a449b888c20",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421194935,
-    "wof:lastmodified":1566584460,
+    "wof:lastmodified":1582351937,
     "wof:name":"Pallatanga",
     "wof:parent_id":1108571001,
     "wof:placetype":"localadmin",

--- a/data/421/195/017/421195017.geojson
+++ b/data/421/195/017/421195017.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009828,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4d0b3462bbd0ac5008e47e0cd391ae95",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421195017,
-    "wof:lastmodified":1566584458,
+    "wof:lastmodified":1582351936,
     "wof:name":"General Proa\u00f1o",
     "wof:parent_id":421191241,
     "wof:placetype":"localadmin",

--- a/data/421/195/039/421195039.geojson
+++ b/data/421/195/039/421195039.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009829,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0a26fd16226851f10c4ad154a634c5a",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421195039,
-    "wof:lastmodified":1566584457,
+    "wof:lastmodified":1582351936,
     "wof:name":"Azogues",
     "wof:parent_id":85670909,
     "wof:placetype":"county",

--- a/data/421/195/117/421195117.geojson
+++ b/data/421/195/117/421195117.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009832,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b1a48ce582e3bd80269573c89f3a3791",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421195117,
-    "wof:lastmodified":1566584457,
+    "wof:lastmodified":1582351936,
     "wof:name":"Olmedo",
     "wof:parent_id":421194445,
     "wof:placetype":"localadmin",

--- a/data/421/195/597/421195597.geojson
+++ b/data/421/195/597/421195597.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009853,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51d2e7181ddd34ffc3ea7477f893972d",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421195597,
-    "wof:lastmodified":1566584458,
+    "wof:lastmodified":1582351936,
     "wof:name":"Ca\u00f1ar",
     "wof:parent_id":85670909,
     "wof:placetype":"county",

--- a/data/421/195/601/421195601.geojson
+++ b/data/421/195/601/421195601.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009853,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0bba4cfff2aaa5df97097dea6c100856",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421195601,
-    "wof:lastmodified":1566584458,
+    "wof:lastmodified":1582351937,
     "wof:name":"Babahoyo",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/421/195/603/421195603.geojson
+++ b/data/421/195/603/421195603.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009853,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"069bb74c7ed5ac89529fa873e6f1523e",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421195603,
-    "wof:lastmodified":1566584457,
+    "wof:lastmodified":1582351936,
     "wof:name":"Celica",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/421/195/605/421195605.geojson
+++ b/data/421/195/605/421195605.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009853,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f033c77ece1dc8154e04aeb4baa2a9bc",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":421195605,
-    "wof:lastmodified":1566584456,
+    "wof:lastmodified":1582351936,
     "wof:name":"Pi\u00f1as",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/421/195/655/421195655.geojson
+++ b/data/421/195/655/421195655.geojson
@@ -85,6 +85,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009855,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"71baf2fe6a9a2a454df5852b1a3d7375",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421195655,
-    "wof:lastmodified":1566584458,
+    "wof:lastmodified":1582351936,
     "wof:name":"Eugenio Espejo",
     "wof:parent_id":421171751,
     "wof:placetype":"localadmin",

--- a/data/421/196/437/421196437.geojson
+++ b/data/421/196/437/421196437.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009881,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d5e0d52a1e2801c46da7c6e1aa1bd25a",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":421196437,
-    "wof:lastmodified":1566584495,
+    "wof:lastmodified":1582351941,
     "wof:name":"Yangana",
     "wof:parent_id":421182159,
     "wof:placetype":"localadmin",

--- a/data/421/196/577/421196577.geojson
+++ b/data/421/196/577/421196577.geojson
@@ -137,6 +137,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009886,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3ad389e53f574cdfe76c21c28487342",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":421196577,
-    "wof:lastmodified":1566584496,
+    "wof:lastmodified":1582351941,
     "wof:name":"Alaus\u00ed",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/197/049/421197049.geojson
+++ b/data/421/197/049/421197049.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f32450f8b049a564e245b1f3264b2fa",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421197049,
-    "wof:lastmodified":1566584500,
+    "wof:lastmodified":1582351942,
     "wof:name":"Cayambe",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/197/117/421197117.geojson
+++ b/data/421/197/117/421197117.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009903,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b04d53c3d738edd25f8b23fe84a275d",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":421197117,
-    "wof:lastmodified":1566584500,
+    "wof:lastmodified":1582351942,
     "wof:name":"Ingapirca",
     "wof:parent_id":421195597,
     "wof:placetype":"localadmin",

--- a/data/421/197/133/421197133.geojson
+++ b/data/421/197/133/421197133.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009903,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dcffc9a821a37e97deae2009ad883a46",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421197133,
-    "wof:lastmodified":1566584499,
+    "wof:lastmodified":1582351941,
     "wof:name":"Nobol",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/197/239/421197239.geojson
+++ b/data/421/197/239/421197239.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009907,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51de0c3e9def54ffac2f58497760c1f9",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421197239,
-    "wof:lastmodified":1566584500,
+    "wof:lastmodified":1582351942,
     "wof:name":"Mont\u00fafar",
     "wof:parent_id":85670967,
     "wof:placetype":"county",

--- a/data/421/197/709/421197709.geojson
+++ b/data/421/197/709/421197709.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009922,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96493ac0eec71fe58a930af6e9c08c5a",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421197709,
-    "wof:lastmodified":1566584500,
+    "wof:lastmodified":1582351941,
     "wof:name":"Santa Lucia",
     "wof:parent_id":421175423,
     "wof:placetype":"localadmin",

--- a/data/421/197/711/421197711.geojson
+++ b/data/421/197/711/421197711.geojson
@@ -286,6 +286,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009922,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"84b5784f7cc4e94d2c66cd5c24a5a5c7",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         }
     ],
     "wof:id":421197711,
-    "wof:lastmodified":1566584501,
+    "wof:lastmodified":1582351942,
     "wof:name":"Santa Cruz",
     "wof:parent_id":421183483,
     "wof:placetype":"locality",

--- a/data/421/198/203/421198203.geojson
+++ b/data/421/198/203/421198203.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459009940,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4206172be0e7ec1f11c383117e7c070d",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421198203,
-    "wof:lastmodified":1566584495,
+    "wof:lastmodified":1582351941,
     "wof:name":"Sigchos",
     "wof:parent_id":421184865,
     "wof:placetype":"localadmin",

--- a/data/421/201/111/421201111.geojson
+++ b/data/421/201/111/421201111.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010051,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67ab999a45d5ea8d9fb1e05bc1522f68",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421201111,
-    "wof:lastmodified":1566584503,
+    "wof:lastmodified":1582351942,
     "wof:name":"Daule",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/201/227/421201227.geojson
+++ b/data/421/201/227/421201227.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f4955e2f1d2282a5fd24f4e9c2e108e",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421201227,
-    "wof:lastmodified":1566584502,
+    "wof:lastmodified":1582351942,
     "wof:name":"Chambo",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/201/625/421201625.geojson
+++ b/data/421/201/625/421201625.geojson
@@ -278,6 +278,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010079,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0385a9c0e8e357082c355ebfbc0de4c6",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
         }
     ],
     "wof:id":421201625,
-    "wof:lastmodified":1566584504,
+    "wof:lastmodified":1582351942,
     "wof:name":"Guano",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/201/631/421201631.geojson
+++ b/data/421/201/631/421201631.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010079,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b68b31145bb0eea6315e21bc854b43af",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421201631,
-    "wof:lastmodified":1566584504,
+    "wof:lastmodified":1582351942,
     "wof:name":"Palora",
     "wof:parent_id":85670935,
     "wof:placetype":"county",

--- a/data/421/201/639/421201639.geojson
+++ b/data/421/201/639/421201639.geojson
@@ -76,6 +76,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010079,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aac9fe7a15fa047ce3af1bf8ac1f4039",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":421201639,
-    "wof:lastmodified":1566584504,
+    "wof:lastmodified":1582351942,
     "wof:name":"Machachi",
     "wof:parent_id":421175413,
     "wof:placetype":"localadmin",

--- a/data/421/202/557/421202557.geojson
+++ b/data/421/202/557/421202557.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010122,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e7241e7dd950279f05e85edf0a0e3da9",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421202557,
-    "wof:lastmodified":1566584470,
+    "wof:lastmodified":1582351938,
     "wof:name":"Salinas",
     "wof:parent_id":421203481,
     "wof:placetype":"localadmin",

--- a/data/421/202/629/421202629.geojson
+++ b/data/421/202/629/421202629.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010124,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52282d52bd04f3b926dcb3861905df91",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421202629,
-    "wof:lastmodified":1566584470,
+    "wof:lastmodified":1582351938,
     "wof:name":"Atacames",
     "wof:parent_id":1108567745,
     "wof:placetype":"localadmin",

--- a/data/421/202/631/421202631.geojson
+++ b/data/421/202/631/421202631.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010124,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a5fb33013a1f511d9ab2267cb7fe306b",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421202631,
-    "wof:lastmodified":1566584472,
+    "wof:lastmodified":1582351938,
     "wof:name":"Calacali",
     "wof:parent_id":421188131,
     "wof:placetype":"localadmin",

--- a/data/421/202/633/421202633.geojson
+++ b/data/421/202/633/421202633.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010124,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6fd609ea73fd41892ed239b19a32c6a9",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421202633,
-    "wof:lastmodified":1566584471,
+    "wof:lastmodified":1582351938,
     "wof:name":"Floreana",
     "wof:parent_id":421183483,
     "wof:placetype":"localadmin",

--- a/data/421/202/635/421202635.geojson
+++ b/data/421/202/635/421202635.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010124,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"90fd51dd80e732f5c1f89f01d5cbad5b",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421202635,
-    "wof:lastmodified":1566584471,
+    "wof:lastmodified":1582351938,
     "wof:name":"Isabela",
     "wof:parent_id":1108569881,
     "wof:placetype":"localadmin",

--- a/data/421/202/683/421202683.geojson
+++ b/data/421/202/683/421202683.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010126,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4b9d7ffbd33def6952fff2df12e71e3c",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421202683,
-    "wof:lastmodified":1566584471,
+    "wof:lastmodified":1582351938,
     "wof:name":"Muisne",
     "wof:parent_id":421169435,
     "wof:placetype":"localadmin",

--- a/data/421/203/379/421203379.geojson
+++ b/data/421/203/379/421203379.geojson
@@ -137,6 +137,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010149,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"16e3719912e58830cb757941ccb09815",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":421203379,
-    "wof:lastmodified":1566584469,
+    "wof:lastmodified":1582351938,
     "wof:name":"Mira",
     "wof:parent_id":85670967,
     "wof:placetype":"county",

--- a/data/421/203/481/421203481.geojson
+++ b/data/421/203/481/421203481.geojson
@@ -200,6 +200,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010154,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37292dc7c4462e3f84fce2de9cb66bc0",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":421203481,
-    "wof:lastmodified":1566584470,
+    "wof:lastmodified":1582351938,
     "wof:name":"Salinas",
     "wof:parent_id":85670979,
     "wof:placetype":"county",

--- a/data/421/203/597/421203597.geojson
+++ b/data/421/203/597/421203597.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010157,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f727bd209c5b7ac8df5622316d5cba60",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421203597,
-    "wof:lastmodified":1566584470,
+    "wof:lastmodified":1582351938,
     "wof:name":"Pedro Vicente Maldonado",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/204/139/421204139.geojson
+++ b/data/421/204/139/421204139.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010175,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"37d8a2c5682cfcb90585d1d3801b5e8b",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421204139,
-    "wof:lastmodified":1566584468,
+    "wof:lastmodified":1582351937,
     "wof:name":"Turi",
     "wof:parent_id":421185495,
     "wof:placetype":"localadmin",

--- a/data/421/204/303/421204303.geojson
+++ b/data/421/204/303/421204303.geojson
@@ -227,6 +227,9 @@
     },
     "wof:country":"EC",
     "wof:created":1459010180,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"479b36371d7ec1ad735834c836bb1d22",
     "wof:hierarchy":[
         {
@@ -237,7 +240,7 @@
         }
     ],
     "wof:id":421204303,
-    "wof:lastmodified":1566584468,
+    "wof:lastmodified":1582351937,
     "wof:name":"Tulc\u00e1n",
     "wof:parent_id":85670967,
     "wof:placetype":"county",

--- a/data/856/322/61/85632261.geojson
+++ b/data/856/322/61/85632261.geojson
@@ -1007,6 +1007,11 @@
     },
     "wof:country":"EC",
     "wof:country_alpha3":"ECU",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"d35eda53fc3287800df5fa8613bc8490",
     "wof:hierarchy":[
         {
@@ -1023,7 +1028,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583979,
+    "wof:lastmodified":1582351928,
     "wof:name":"Ecuador",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/708/85/85670885.geojson
+++ b/data/856/708/85/85670885.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Azuay Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9563c22c6da7142f933f7c56ba755e11",
     "wof:hierarchy":[
         {
@@ -329,7 +332,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583970,
+    "wof:lastmodified":1582351924,
     "wof:name":"Azuay",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/708/87/85670887.geojson
+++ b/data/856/708/87/85670887.geojson
@@ -300,6 +300,9 @@
         "wk:page":"El Oro Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5dd9abfe8eb652fa3852051ae429035",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583968,
+    "wof:lastmodified":1582351923,
     "wof:name":"El Oro",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/708/91/85670891.geojson
+++ b/data/856/708/91/85670891.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Loja Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"da95a1c7d5ad57160308c95890546bd5",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583969,
+    "wof:lastmodified":1582351924,
     "wof:name":"Loja",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/708/95/85670895.geojson
+++ b/data/856/708/95/85670895.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Zamora-Chinchipe Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a42aaca9d5d25cbd211351860d619f0c",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583967,
+    "wof:lastmodified":1582351923,
     "wof:name":"Zamora Chinchipe",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/708/99/85670899.geojson
+++ b/data/856/708/99/85670899.geojson
@@ -311,6 +311,9 @@
         "wk:page":"Gal\u00e1pagos Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e9d17c1455a06dba16e9b6870e89cd2a",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583970,
+    "wof:lastmodified":1582351924,
     "wof:name":"Gal\u00e1pagos",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/05/85670905.geojson
+++ b/data/856/709/05/85670905.geojson
@@ -305,6 +305,9 @@
         "wk:page":"Bol\u00edvar Province (Ecuador)"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4717f0c0b58b2f54745645e1eca17058",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583972,
+    "wof:lastmodified":1582351925,
     "wof:name":"Bolivar",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/09/85670909.geojson
+++ b/data/856/709/09/85670909.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Ca\u00f1ar Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"32e6694b99d749703dd8ef96a821489c",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583974,
+    "wof:lastmodified":1582351926,
     "wof:name":"Ca\u00f1ar",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/15/85670915.geojson
+++ b/data/856/709/15/85670915.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Cotopaxi Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b17f2daa71da6d8358774c929b4777a",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583977,
+    "wof:lastmodified":1582351927,
     "wof:name":"Cotopaxi",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/17/85670917.geojson
+++ b/data/856/709/17/85670917.geojson
@@ -315,6 +315,9 @@
         "wk:page":"Guayas Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f525b9e5f5fe39c873bb05589717bdc0",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583973,
+    "wof:lastmodified":1582351925,
     "wof:name":"Guayas",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/23/85670923.geojson
+++ b/data/856/709/23/85670923.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Los R\u00edos Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"973a82f323319880ae176d9e7062eb51",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583977,
+    "wof:lastmodified":1582351927,
     "wof:name":"Los Rios",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/27/85670927.geojson
+++ b/data/856/709/27/85670927.geojson
@@ -313,6 +313,9 @@
         "wk:page":"Manab\u00ed Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"837fd9108f3866fa0cdee0e94a676f0c",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583972,
+    "wof:lastmodified":1582351925,
     "wof:name":"Manabi",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/31/85670931.geojson
+++ b/data/856/709/31/85670931.geojson
@@ -325,6 +325,9 @@
         "wk:page":"Chimborazo Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35d2ecdfd2632f2258b03a3647e061a0",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583974,
+    "wof:lastmodified":1582351926,
     "wof:name":"Chimborazo",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/35/85670935.geojson
+++ b/data/856/709/35/85670935.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Morona-Santiago Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"20419b0a34337beb4a2fd4d7945ff5b8",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583971,
+    "wof:lastmodified":1582351925,
     "wof:name":"Morona Santiago",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/41/85670941.geojson
+++ b/data/856/709/41/85670941.geojson
@@ -310,6 +310,9 @@
         "wk:page":"Orellana Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c06393da516008362e6e9200df07e48",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583975,
+    "wof:lastmodified":1582351926,
     "wof:name":"Orellana",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/45/85670945.geojson
+++ b/data/856/709/45/85670945.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Pichincha Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"09b25f24f8911f3cd26794ab11481ed5",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583973,
+    "wof:lastmodified":1582351925,
     "wof:name":"Pichincha",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/49/85670949.geojson
+++ b/data/856/709/49/85670949.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Pastaza Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"75c512f0300c46bac47501f74128bed9",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583978,
+    "wof:lastmodified":1582351927,
     "wof:name":"Pastaza",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/53/85670953.geojson
+++ b/data/856/709/53/85670953.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Tungurahua Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e9bb70867378e52cd3ad2364275773e",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583974,
+    "wof:lastmodified":1582351926,
     "wof:name":"Napo",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/59/85670959.geojson
+++ b/data/856/709/59/85670959.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Napo Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc9b82263f11d35d2a086e53d779f2d3",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583970,
+    "wof:lastmodified":1582351925,
     "wof:name":"Tungurahua",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/63/85670963.geojson
+++ b/data/856/709/63/85670963.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Esmeraldas Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a36eb21bb99f90d109c3bb4ce4c64df3",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583974,
+    "wof:lastmodified":1582351926,
     "wof:name":"Esmeraldas",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/67/85670967.geojson
+++ b/data/856/709/67/85670967.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Carchi Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e4cda829d0d5516347af9a9cf79b418",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583971,
+    "wof:lastmodified":1582351925,
     "wof:name":"Carchi",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/71/85670971.geojson
+++ b/data/856/709/71/85670971.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Imbabura Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08a8e901b6776b3e221477d3c7a31af2",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583978,
+    "wof:lastmodified":1582351927,
     "wof:name":"Imbabura",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/77/85670977.geojson
+++ b/data/856/709/77/85670977.geojson
@@ -305,6 +305,9 @@
         "wk:page":"Sucumb\u00edos Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2bb0f1461d085b720179dbec4f057e3d",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583976,
+    "wof:lastmodified":1582351926,
     "wof:name":"Sucumbios",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/79/85670979.geojson
+++ b/data/856/709/79/85670979.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Santa Elena Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23a6f272461848ed842fcd49c081e43d",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583975,
+    "wof:lastmodified":1582351926,
     "wof:name":"Santa Elena",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/83/85670983.geojson
+++ b/data/856/709/83/85670983.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Santo Domingo de los Ts\u00e1chilas Province"
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf79d928f76bf1f15f153a43421c9899",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566583976,
+    "wof:lastmodified":1582351926,
     "wof:name":"Santo Domingo de los Ts\u00e1chilas",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/857/648/29/85764829.geojson
+++ b/data/857/648/29/85764829.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":1054069
     },
     "wof:country":"EC",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5010fce32b6b3fa06b3a1d910e231f16",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566583967,
+    "wof:lastmodified":1582351923,
     "wof:name":"C. del Seguro Urbanizaci\u00f3n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/451/517/890451517.geojson
+++ b/data/890/451/517/890451517.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"EC",
     "wof:created":1469052783,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de6c6b4c0bf1074203644745d330db5b",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":890451517,
-    "wof:lastmodified":1566584527,
+    "wof:lastmodified":1582351945,
     "wof:name":"San Fernando",
     "wof:parent_id":85670885,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.