### PR TITLE
Name updates

### DIFF
--- a/data/112/537/354/3/1125373543.geojson
+++ b/data/112/537/354/3/1125373543.geojson
@@ -40,6 +40,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0413\u0443\u0430\u044f\u043a\u0456\u043b\u044c"
     ],
+    "name:bel_x_variant":[
+        "\u0413\u0443\u0430\u044f\u043a\u0456\u043b\u044c"
+    ],
     "name:ben_x_preferred":[
         "\u0997\u09c1\u09af\u09bc\u09be\u0987\u09af\u09bc\u09be\u0995\u09bf\u09b2"
     ],
@@ -250,6 +253,9 @@
     "name:srp_x_preferred":[
         "\u0413\u0432\u0430\u0458\u0430\u043a\u0438\u043b"
     ],
+    "name:swa_x_preferred":[
+        "Guayaquil"
+    ],
     "name:swe_x_preferred":[
         "Guayaquil"
     ],
@@ -264,6 +270,9 @@
     ],
     "name:tat_x_preferred":[
         "\u0413\u0443\u0430\u044f\u043a\u0438\u043b"
+    ],
+    "name:tat_x_variant":[
+        "\u0413\u0432\u0430\u044f\u043a\u0438\u043b"
     ],
     "name:tel_x_preferred":[
         "\u0c17\u0c4d\u0c35\u0c3e\u0c2f\u0c3e\u0c15\u0c4d\u0c35\u0c3f\u0c32\u0c4d"
@@ -285,6 +294,9 @@
     ],
     "name:urd_x_variant":[
         "\u06af\u0648\u06cc\u0627\u06a9\u06cc\u0644"
+    ],
+    "name:uzb_x_preferred":[
+        "Guayakil"
     ],
     "name:vep_x_preferred":[
         "Guajakil"
@@ -346,8 +358,8 @@
     "wof:belongsto":[
         102191577,
         85632261,
-        85670917,
-        421175423
+        421175423,
+        85670917
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -370,7 +382,7 @@
         }
     ],
     "wof:id":1125373543,
-    "wof:lastmodified":1566584528,
+    "wof:lastmodified":1587428950,
     "wof:name":"Guayaquil",
     "wof:parent_id":421175423,
     "wof:placetype":"localadmin",

--- a/data/421/166/689/421166689.geojson
+++ b/data/421/166/689/421166689.geojson
@@ -126,7 +126,7 @@
         "\u0baa\u0bc2\u0baf\u0bcb"
     ],
     "name:tam_x_variant":[
-        "\u0baa\u0bc2\u0baf\u0bcb "
+        "\u0baa\u0bc2\u0baf\u0bcb"
     ],
     "name:tel_x_preferred":[
         "\u0c2a\u0c41\u0c2f\u0c4b"
@@ -277,8 +277,8 @@
     "wof:belongsto":[
         102191577,
         85632261,
-        85670949,
-        421185499
+        421185499,
+        85670949
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -301,7 +301,7 @@
         }
     ],
     "wof:id":421166689,
-    "wof:lastmodified":1566584452,
+    "wof:lastmodified":1587163137,
     "wof:name":"Puyo",
     "wof:parent_id":421185499,
     "wof:placetype":"locality",

--- a/data/421/169/109/421169109.geojson
+++ b/data/421/169/109/421169109.geojson
@@ -32,6 +32,9 @@
     "name:arg_x_preferred":[
         "Quito"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u062a\u0648"
+    ],
     "name:ast_x_preferred":[
         "Quitu"
     ],
@@ -83,17 +86,32 @@
     "name:che_x_preferred":[
         "\u041a\u0438\u0442\u043e"
     ],
+    "name:ckb_x_preferred":[
+        "\u06a9\u06cc\u062a\u06c6"
+    ],
     "name:cym_x_preferred":[
         "Quito"
     ],
     "name:dan_x_preferred":[
         "Quito"
     ],
+    "name:deu_ch_x_preferred":[
+        "Quito"
+    ],
     "name:deu_x_preferred":[
+        "Quito"
+    ],
+    "name:diq_x_preferred":[
         "Quito"
     ],
     "name:ell_x_preferred":[
         "\u039a\u03af\u03c4\u03bf"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Quito"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Quito"
     ],
     "name:eng_x_preferred":[
         "Quito"
@@ -326,6 +344,9 @@
     "name:pol_x_preferred":[
         "Quito"
     ],
+    "name:por_br_x_preferred":[
+        "Quito"
+    ],
     "name:por_x_preferred":[
         "Quito"
     ],
@@ -400,6 +421,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c15\u0c40\u0c1f\u0c4b"
+    ],
+    "name:tgk_x_preferred":[
+        "\u041a\u0438\u0442\u043e"
     ],
     "name:tgl_x_preferred":[
         "Quito"
@@ -579,8 +603,8 @@
     "wof:belongsto":[
         102191577,
         85632261,
-        85670945,
-        421188131
+        421188131,
+        85670945
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -606,7 +630,7 @@
         }
     ],
     "wof:id":421169109,
-    "wof:lastmodified":1582351937,
+    "wof:lastmodified":1587428949,
     "wof:name":"Quito",
     "wof:parent_id":421188131,
     "wof:placetype":"localadmin",

--- a/data/421/186/705/421186705.geojson
+++ b/data/421/186/705/421186705.geojson
@@ -35,6 +35,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0413\u0443\u0430\u044f\u043a\u0456\u043b\u044c"
     ],
+    "name:bel_x_variant":[
+        "\u0413\u0443\u0430\u044f\u043a\u0456\u043b\u044c"
+    ],
     "name:ben_x_preferred":[
         "\u0997\u09c1\u09af\u09bc\u09be\u0995\u09c1\u0987\u09b2"
     ],
@@ -242,6 +245,9 @@
     "name:srp_x_preferred":[
         "\u0413\u0432\u0430\u0458\u0430\u043a\u0438\u043b"
     ],
+    "name:swa_x_preferred":[
+        "Guayaquil"
+    ],
     "name:swe_x_preferred":[
         "Guayaquil"
     ],
@@ -256,6 +262,9 @@
     ],
     "name:tat_x_preferred":[
         "\u0413\u0443\u0430\u044f\u043a\u0438\u043b"
+    ],
+    "name:tat_x_variant":[
+        "\u0413\u0432\u0430\u044f\u043a\u0438\u043b"
     ],
     "name:tel_x_preferred":[
         "\u0c17\u0c4d\u0c35\u0c3e\u0c2f\u0c3e\u0c15\u0c4d\u0c35\u0c3f\u0c32\u0c4d"
@@ -274,6 +283,9 @@
     ],
     "name:urd_x_preferred":[
         "\u06af\u0648\u06cc\u0627\u06a9\u06cc\u0644"
+    ],
+    "name:uzb_x_preferred":[
+        "Guayakil"
     ],
     "name:vep_x_preferred":[
         "Guajakil'"
@@ -330,8 +342,8 @@
     "wof:belongsto":[
         102191577,
         85632261,
-        85670917,
-        421175423
+        421175423,
+        85670917
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -352,7 +364,7 @@
         }
     ],
     "wof:id":421186705,
-    "wof:lastmodified":1566584489,
+    "wof:lastmodified":1587428950,
     "wof:name":"Guayaquil",
     "wof:parent_id":421175423,
     "wof:placetype":"locality",

--- a/data/856/322/61/85632261.geojson
+++ b/data/856/322/61/85632261.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":20.814053,
-    "geom:area_square_m":257216514851.116882,
+    "geom:area_square_m":257216514823.684357,
     "geom:bbox":"-92.011559,-5.013975,-75.188794,1.665833",
     "geom:latitude":-1.426932,
     "geom:longitude":-78.775014,
@@ -61,6 +61,9 @@
     ],
     "name:arg_x_preferred":[
         "Ecuador"
+    ],
+    "name:ary_x_preferred":[
+        "\u0644\u0625\u0643\u0648\u0627\u062f\u0648\u0631"
     ],
     "name:arz_x_preferred":[
         "\u0627\u0643\u0648\u0627\u062f\u0648\u0631"
@@ -162,6 +165,12 @@
     "name:dan_x_preferred":[
         "Ecuador"
     ],
+    "name:deu_at_x_preferred":[
+        "Ecuador"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Ecuador"
+    ],
     "name:deu_x_preferred":[
         "Ecuador"
     ],
@@ -185,6 +194,12 @@
     ],
     "name:ell_x_variant":[
         "\u0395\u03ba\u03bf\u03c5\u03b1\u03b4\u03cc\u03c1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Ecuador"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Ecuador"
     ],
     "name:eng_x_preferred":[
         "Ecuador"
@@ -252,6 +267,9 @@
     "name:gag_x_preferred":[
         "Ekvador"
     ],
+    "name:gcr_x_preferred":[
+        "L\u00e9kwat\u00f2"
+    ],
     "name:gla_x_preferred":[
         "Eacuador"
     ],
@@ -266,6 +284,9 @@
     ],
     "name:gom_x_preferred":[
         "\u0907\u0915\u094d\u0935\u093e\u0921\u094b\u0930"
+    ],
+    "name:got_x_preferred":[
+        "\ud800\udf34\ud800\udf3a\ud800\udf45\ud800\udf30\ud800\udf33\ud800\udf30\ud800\udf3f\ud800\udf42"
     ],
     "name:grn_x_preferred":[
         "Ekuator"
@@ -627,6 +648,9 @@
     "name:pol_x_preferred":[
         "Ekwador"
     ],
+    "name:por_br_x_preferred":[
+        "Equador"
+    ],
     "name:por_x_preferred":[
         "Equador"
     ],
@@ -699,6 +723,9 @@
     "name:sna_x_preferred":[
         "Ecuador"
     ],
+    "name:snd_x_preferred":[
+        "\u0627\u064a\u06aa\u0648\u0627\u068a\u0648\u0631"
+    ],
     "name:som_x_preferred":[
         "Ikwadoor"
     ],
@@ -716,6 +743,15 @@
     ],
     "name:sqi_x_variant":[
         "Ekuator"
+    ],
+    "name:srd_x_preferred":[
+        "Ecuador"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u0415\u043a\u0432\u0430\u0434\u043e\u0440"
+    ],
+    "name:srp_el_x_preferred":[
+        "Ekvador"
     ],
     "name:srp_x_preferred":[
         "\u0415\u043a\u0432\u0430\u0434\u043e\u0440"
@@ -737,6 +773,9 @@
     ],
     "name:szl_x_preferred":[
         "Ekwad\u016fr"
+    ],
+    "name:szy_x_preferred":[
+        "Ecuador"
     ],
     "name:tah_x_preferred":[
         "Ecuador"
@@ -777,6 +816,9 @@
     "name:tir_x_preferred":[
         "\u12a2\u12b3\u12f6\u122d"
     ],
+    "name:tir_x_variant":[
+        "\u12a4\u12b3\u12f6\u122d"
+    ],
     "name:ton_x_preferred":[
         "\u02bbEkuetoa"
     ],
@@ -788,6 +830,9 @@
     ],
     "name:tur_x_preferred":[
         "Ekvador"
+    ],
+    "name:udm_x_preferred":[
+        "\u042d\u043a\u0432\u0430\u0434\u043e\u0440"
     ],
     "name:uig_x_preferred":[
         "\u0626\u06d0\u0643\u06cb\u0627\u062f\u0648\u0631"
@@ -862,8 +907,26 @@
     "name:zha_x_preferred":[
         "Ecuador"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u5384\u74dc\u591a\u5c14"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5384\u74dc\u591a\u723e"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Ecuador"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u5384\u74dc\u591a\u723e"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u5384\u74dc\u591a\u5c14"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u5384\u74dc\u591a\u5c14"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5384\u74dc\u591a"
     ],
     "name:zho_x_preferred":[
         "\u5384\u74dc\u591a\u5c14"
@@ -1029,7 +1092,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1583797328,
+    "wof:lastmodified":1587428947,
     "wof:name":"Ecuador",
     "wof:parent_id":102191577,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.