### PR TITLE
ec concordances, placetype local, and more

### DIFF
--- a/data/110/856/756/3/1108567563.geojson
+++ b/data/110/856/756/3/1108567563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018096,
-    "geom:area_square_m":223635538.33881,
+    "geom:area_square_m":223635520.376824,
     "geom:bbox":"-79.643467,-2.026529,-79.438224,-1.880151",
     "geom:latitude":-1.945813,
     "geom:longitude":-79.542292,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.GY.AB",
         "wd:id":"Q2466508"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064358,
-    "wof:geomhash":"5bab06baf127fc5db498a7a865b24e0e",
+    "wof:geomhash":"acb955ec62ee20a09f1670180d96a48a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108567563,
-    "wof:lastmodified":1690875603,
+    "wof:lastmodified":1695886626,
     "wof:name":"Alfredo Baquerizo Moreno",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/856/760/3/1108567603.geojson
+++ b/data/110/856/760/3/1108567603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083108,
-    "geom:area_square_m":1027385953.301509,
+    "geom:area_square_m":1027385519.825909,
     "geom:bbox":"-78.936449,-1.470084,-78.534667,-1.105231",
     "geom:latitude":-1.276341,
     "geom:longitude":-78.748775,
@@ -116,9 +116,10 @@
         "hasc:id":"EC.TU.AM",
         "wd:id":"Q1990525"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064359,
-    "wof:geomhash":"85375c620d2a850db5422c1546fde834",
+    "wof:geomhash":"4ecc28401b320c27655cf9357821aed1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108567603,
-    "wof:lastmodified":1690875602,
+    "wof:lastmodified":1695886044,
     "wof:name":"Ambato",
     "wof:parent_id":85670959,
     "wof:placetype":"county",

--- a/data/110/856/766/9/1108567669.geojson
+++ b/data/110/856/766/9/1108567669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.245122,
-    "geom:area_square_m":3030740103.941389,
+    "geom:area_square_m":3030741357.588157,
     "geom:bbox":"-78.411189,-0.975498,-77.495811,-0.455265",
     "geom:latitude":-0.717642,
     "geom:longitude":-77.932302,
@@ -117,9 +117,10 @@
         "hasc:id":"EC.NA.AR",
         "wd:id":"Q2448757"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064362,
-    "wof:geomhash":"cdc7db0ff53f8a29e043ebe9f13f3fe1",
+    "wof:geomhash":"ba0d1abf640f213cd15f5450caeabe41",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108567669,
-    "wof:lastmodified":1690875604,
+    "wof:lastmodified":1695886626,
     "wof:name":"Archidona",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/856/770/5/1108567705.geojson
+++ b/data/110/856/770/5/1108567705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065921,
-    "geom:area_square_m":813511246.472152,
+    "geom:area_square_m":813510953.599141,
     "geom:bbox":"-80.218229,-3.784194,-79.924083,-3.391652",
     "geom:latitude":-3.599601,
     "geom:longitude":-80.08963,
@@ -113,9 +113,10 @@
         "hasc:id":"EC.EO.AR",
         "wd:id":"Q2448877"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064363,
-    "wof:geomhash":"5a519c6822238c3c1341ffc6119334cf",
+    "wof:geomhash":"614799b97acb23371824d4241ea9befc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108567705,
-    "wof:lastmodified":1690875601,
+    "wof:lastmodified":1695886626,
     "wof:name":"Arenillas",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/110/856/774/5/1108567745.geojson
+++ b/data/110/856/774/5/1108567745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037373,
-    "geom:area_square_m":462080427.002523,
+    "geom:area_square_m":462080577.445347,
     "geom:bbox":"-80.014079,0.639755,-79.726411,0.951988",
     "geom:latitude":0.78511,
     "geom:longitude":-79.853802,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.ES.AT",
         "wd:id":"Q3991161"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064365,
-    "wof:geomhash":"b00c47b3469b592f3a43ac1956420f23",
+    "wof:geomhash":"48d9bb586f003dadca25f732a6cc2105",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108567745,
-    "wof:lastmodified":1690875605,
+    "wof:lastmodified":1695886627,
     "wof:name":"Atacames",
     "wof:parent_id":85670963,
     "wof:placetype":"county",

--- a/data/110/856/784/1/1108567841.geojson
+++ b/data/110/856/784/1/1108567841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04132,
-    "geom:area_square_m":510704123.567919,
+    "geom:area_square_m":510704431.452047,
     "geom:bbox":"-79.749971,-1.889229,-79.573223,-1.44378",
     "geom:latitude":-1.675923,
     "geom:longitude":-79.658199,
@@ -113,9 +113,10 @@
         "hasc:id":"EC.LR.BB",
         "wd:id":"Q1990086"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064369,
-    "wof:geomhash":"457fbc855cbb3ac7b142392da770945f",
+    "wof:geomhash":"26c1e035c66f384d0ae549066e57543d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108567841,
-    "wof:lastmodified":1690875601,
+    "wof:lastmodified":1695886626,
     "wof:name":"Baba",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/110/856/787/5/1108567875.geojson
+++ b/data/110/856/787/5/1108567875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038972,
-    "geom:area_square_m":481285219.985698,
+    "geom:area_square_m":481285177.928224,
     "geom:bbox":"-79.855415,-2.993358,-79.505514,-2.786697",
     "geom:latitude":-2.894096,
     "geom:longitude":-79.711392,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.GY.BO",
         "wd:id":"Q1990431"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064370,
-    "wof:geomhash":"746ddbf656913e6cb7fde069bee6275f",
+    "wof:geomhash":"4cdd18bc73ed6153ee73197d51b856b7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108567875,
-    "wof:lastmodified":1690875605,
+    "wof:lastmodified":1695886627,
     "wof:name":"Balao",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/856/791/5/1108567915.geojson
+++ b/data/110/856/791/5/1108567915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005433,
-    "geom:area_square_m":67038028.664069,
+    "geom:area_square_m":67038015.268531,
     "geom:bbox":"-79.877855,-3.822264,-79.788607,-3.720088",
     "geom:latitude":-3.765213,
     "geom:longitude":-79.837816,
@@ -143,9 +143,10 @@
         "hasc:id":"EC.EO.BA",
         "wd:id":"Q2448322"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064372,
-    "wof:geomhash":"a9f35bd39b9902080f9df81ef42c7c0b",
+    "wof:geomhash":"e56262dc543cd0e83289f6d67cfb4312",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1108567915,
-    "wof:lastmodified":1690875598,
+    "wof:lastmodified":1695886045,
     "wof:name":"Balsas",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/110/856/794/9/1108567949.geojson
+++ b/data/110/856/794/9/1108567949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097192,
-    "geom:area_square_m":1201498439.705612,
+    "geom:area_square_m":1201498027.302186,
     "geom:bbox":"-80.152504,-1.531162,-79.65924,-1.073129",
     "geom:latitude":-1.287742,
     "geom:longitude":-79.906617,
@@ -110,9 +110,10 @@
         "hasc:id":"EC.GY.BZ",
         "wd:id":"Q1989901"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064373,
-    "wof:geomhash":"81b35576f665cf4f04ba0ba1809deb64",
+    "wof:geomhash":"508709ec26b116ca523bedd50032ae69",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108567949,
-    "wof:lastmodified":1690875602,
+    "wof:lastmodified":1695886626,
     "wof:name":"Balzar",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/856/799/5/1108567995.geojson
+++ b/data/110/856/799/5/1108567995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08727,
-    "geom:area_square_m":1078821049.767783,
+    "geom:area_square_m":1078821248.01506,
     "geom:bbox":"-78.475634,-1.519016,-78.109639,-1.135846",
     "geom:latitude":-1.334696,
     "geom:longitude":-78.272646,
@@ -110,9 +110,10 @@
         "hasc:id":"EC.TU.BA",
         "wd:id":"Q3655923"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064375,
-    "wof:geomhash":"89d96a567f09fc41ced1787928c77432",
+    "wof:geomhash":"f78b1dfb1086e651e048669b7783aa4b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108567995,
-    "wof:lastmodified":1690875597,
+    "wof:lastmodified":1695886624,
     "wof:name":"Ba\u00f1os",
     "wof:parent_id":85670959,
     "wof:placetype":"county",

--- a/data/110/856/807/3/1108568073.geojson
+++ b/data/110/856/807/3/1108568073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030786,
-    "geom:area_square_m":380658349.220588,
+    "geom:area_square_m":380658599.413973,
     "geom:bbox":"-78.061429,0.355629,-77.769375,0.584002",
     "geom:latitude":0.473429,
     "geom:longitude":-77.908728,
@@ -61,9 +61,10 @@
     "wof:concordances":{
         "hasc:id":"EC.CR.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064378,
-    "wof:geomhash":"67203c100bba57353ccf411a6e3c9b33",
+    "wof:geomhash":"318c538aef112cb7917e4cd83bf39c92",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -73,7 +74,7 @@
         }
     ],
     "wof:id":1108568073,
-    "wof:lastmodified":1627522037,
+    "wof:lastmodified":1695886548,
     "wof:name":"Bol\u00edvar",
     "wof:parent_id":85670967,
     "wof:placetype":"county",

--- a/data/110/856/812/1/1108568121.geojson
+++ b/data/110/856/812/1/1108568121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042459,
-    "geom:area_square_m":524953267.083834,
+    "geom:area_square_m":524953288.870867,
     "geom:bbox":"-80.234851,-1.044684,-79.870805,-0.809117",
     "geom:latitude":-0.908739,
     "geom:longitude":-80.029297,
@@ -61,9 +61,10 @@
     "wof:concordances":{
         "hasc:id":"EC.MN.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064379,
-    "wof:geomhash":"5f70e2bcc30b4949a12a4bdff79b4b98",
+    "wof:geomhash":"8bcc628b99d6a9b4e2290b9f5b9c62de",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -73,7 +74,7 @@
         }
     ],
     "wof:id":1108568121,
-    "wof:lastmodified":1627522037,
+    "wof:lastmodified":1695886548,
     "wof:name":"Bol\u00edvar",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/110/856/816/5/1108568165.geojson
+++ b/data/110/856/816/5/1108568165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046837,
-    "geom:area_square_m":579102106.729541,
+    "geom:area_square_m":579102501.298078,
     "geom:bbox":"-79.608549,-0.957943,-79.34271,-0.532686",
     "geom:latitude":-0.718106,
     "geom:longitude":-79.478629,
@@ -61,9 +61,10 @@
     "wof:concordances":{
         "hasc:id":"EC.LR.BF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064381,
-    "wof:geomhash":"7a2a6270783c33b42c746d8e48fbd564",
+    "wof:geomhash":"d542e728e5ce7ae3f1895ca36141878f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -73,7 +74,7 @@
         }
     ],
     "wof:id":1108568165,
-    "wof:lastmodified":1627522037,
+    "wof:lastmodified":1695886548,
     "wof:name":"Buena F\u00e9",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/110/856/819/9/1108568199.geojson
+++ b/data/110/856/819/9/1108568199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014333,
-    "geom:area_square_m":177159830.818262,
+    "geom:area_square_m":177159616.909415,
     "geom:bbox":"-79.347055,-1.655802,-79.093366,-1.533263",
     "geom:latitude":-1.606658,
     "geom:longitude":-79.216079,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.BO.CA",
         "wd:id":"Q605964"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064382,
-    "wof:geomhash":"0367465eb63d7a22e4083b60416034fd",
+    "wof:geomhash":"bdefb1e5c3e18a2524eb682580c6705b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108568199,
-    "wof:lastmodified":1690875599,
+    "wof:lastmodified":1695886625,
     "wof:name":"Caluma",
     "wof:parent_id":85670905,
     "wof:placetype":"county",

--- a/data/110/856/823/9/1108568239.geojson
+++ b/data/110/856/823/9/1108568239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06834,
-    "geom:area_square_m":842614899.703794,
+    "geom:area_square_m":842614791.156523,
     "geom:bbox":"-79.766877,-4.527314,-79.42339,-4.147591",
     "geom:latitude":-4.337074,
     "geom:longitude":-79.600057,
@@ -104,9 +104,10 @@
         "hasc:id":"EC.LJ.CV",
         "wd:id":"Q1989880"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064384,
-    "wof:geomhash":"d2302bc6a65896fdc44451e25c83697e",
+    "wof:geomhash":"53b144535b58d770d027a3b4f02078c0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108568239,
-    "wof:lastmodified":1690875604,
+    "wof:lastmodified":1695886627,
     "wof:name":"Calvas",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/110/856/828/3/1108568283.geojson
+++ b/data/110/856/828/3/1108568283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096062,
-    "geom:area_square_m":1187815384.591897,
+    "geom:area_square_m":1187814583.058246,
     "geom:bbox":"-77.39085,-0.102215,-77.036484,0.391844",
     "geom:latitude":0.139246,
     "geom:longitude":-77.217466,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.SU.CA",
         "wd:id":"Q976081"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064385,
-    "wof:geomhash":"5a1ad172c99b179f7a335ef6c8cf3f36",
+    "wof:geomhash":"f5e460510b74eb57a02b34794c81fea7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108568283,
-    "wof:lastmodified":1690875598,
+    "wof:lastmodified":1695886625,
     "wof:name":"Cascales",
     "wof:parent_id":85670977,
     "wof:placetype":"county",

--- a/data/110/856/832/5/1108568325.geojson
+++ b/data/110/856/832/5/1108568325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053263,
-    "geom:area_square_m":657021492.092427,
+    "geom:area_square_m":657021324.751378,
     "geom:bbox":"-79.581006,-4.181199,-79.220898,-3.794885",
     "geom:latitude":-3.982457,
     "geom:longitude":-79.393146,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.LJ.CT",
         "wd:id":"Q1989912"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064386,
-    "wof:geomhash":"6b79367c9eedc80494dc6c5b836e5db8",
+    "wof:geomhash":"d1d6e0164f9d92167e078e3927f2aa32",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108568325,
-    "wof:lastmodified":1690875600,
+    "wof:lastmodified":1695886625,
     "wof:name":"Catamayo",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/110/856/844/7/1108568447.geojson
+++ b/data/110/856/844/7/1108568447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001481,
-    "geom:area_square_m":18309198.800858,
+    "geom:area_square_m":18309319.372735,
     "geom:bbox":"-78.636881,-1.370727,-78.586406,-1.321614",
     "geom:latitude":-1.348089,
     "geom:longitude":-78.608866,
@@ -104,9 +104,10 @@
         "hasc:id":"EC.TU.CE",
         "wd:id":"Q1990478"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064391,
-    "wof:geomhash":"5faf762b073a6fadb1da419cf6418999",
+    "wof:geomhash":"ca53974e8d0c2b89cac563b124a78718",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108568447,
-    "wof:lastmodified":1690875599,
+    "wof:lastmodified":1695886625,
     "wof:name":"Cevallos",
     "wof:parent_id":85670959,
     "wof:placetype":"county",

--- a/data/110/856/848/1/1108568481.geojson
+++ b/data/110/856/848/1/1108568481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025646,
-    "geom:area_square_m":316399371.965058,
+    "geom:area_square_m":316399191.479809,
     "geom:bbox":"-79.806415,-3.945992,-79.5556,-3.745854",
     "geom:latitude":-3.851127,
     "geom:longitude":-79.668918,
@@ -98,9 +98,10 @@
         "hasc:id":"EC.LJ.CP",
         "wd:id":"Q1989999"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064392,
-    "wof:geomhash":"2eb30d50a46cbd0ce421626a8d9a7721",
+    "wof:geomhash":"36eb329dbcbf1fea5bd110b7e14f1c24",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108568481,
-    "wof:lastmodified":1690875604,
+    "wof:lastmodified":1695886626,
     "wof:name":"Chaguarpamba",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/110/856/854/3/1108568543.geojson
+++ b/data/110/856/854/3/1108568543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026577,
-    "geom:area_square_m":328035130.352674,
+    "geom:area_square_m":328034921.612158,
     "geom:bbox":"-79.737303,-3.544547,-79.538774,-3.322138",
     "geom:latitude":-3.438842,
     "geom:longitude":-79.626518,
@@ -104,9 +104,10 @@
         "hasc:id":"EC.EO.CH",
         "wd:id":"Q2448742"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064394,
-    "wof:geomhash":"8588a4066a79e46356bbde995f06f39f",
+    "wof:geomhash":"9d2cdc797b08679d3fb4ba37b07b1c39",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108568543,
-    "wof:lastmodified":1690875605,
+    "wof:lastmodified":1695886627,
     "wof:name":"Chilla",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/110/856/857/7/1108568577.geojson
+++ b/data/110/856/857/7/1108568577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053712,
-    "geom:area_square_m":663744732.287989,
+    "geom:area_square_m":663744889.464719,
     "geom:bbox":"-79.261152,-2.196502,-79.001371,-1.8642",
     "geom:latitude":-2.009235,
     "geom:longitude":-79.119397,
@@ -110,9 +110,10 @@
         "hasc:id":"EC.BO.CN",
         "wd:id":"Q2466598"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064396,
-    "wof:geomhash":"b587631d374782e77ff0072ea930c9ba",
+    "wof:geomhash":"c0ae994203c0ec2d81b8e6a5eeef03f6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108568577,
-    "wof:lastmodified":1690875600,
+    "wof:lastmodified":1695886625,
     "wof:name":"Chillanes",
     "wof:parent_id":85670905,
     "wof:placetype":"county",

--- a/data/110/856/861/1/1108568611.geojson
+++ b/data/110/856/861/1/1108568611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0213,
-    "geom:area_square_m":263261284.099448,
+    "geom:area_square_m":263261476.320342,
     "geom:bbox":"-79.287045,-1.739599,-79.002394,-1.604089",
     "geom:latitude":-1.670951,
     "geom:longitude":-79.142349,
@@ -110,9 +110,10 @@
         "hasc:id":"EC.BO.CB",
         "wd:id":"Q2466566"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064397,
-    "wof:geomhash":"b08238626e96c9ecfc12021975cf1536",
+    "wof:geomhash":"808e295c880b72a9deaee5cb40f50731",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108568611,
-    "wof:lastmodified":1690875599,
+    "wof:lastmodified":1695886625,
     "wof:name":"Chimbo",
     "wof:parent_id":85670905,
     "wof:placetype":"county",

--- a/data/110/856/868/9/1108568689.geojson
+++ b/data/110/856/868/9/1108568689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062874,
-    "geom:area_square_m":777172481.746099,
+    "geom:area_square_m":777172258.934739,
     "geom:bbox":"-80.285435,-1.671813,-79.866578,-1.349883",
     "geom:latitude":-1.528701,
     "geom:longitude":-80.086365,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.GY.CO",
         "wd:id":"Q1990070"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064402,
-    "wof:geomhash":"cea429e6a93fb207a229dcc2a9a2ccb1",
+    "wof:geomhash":"ce45d1ced2269f3f5080e09e2f8b015a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108568689,
-    "wof:lastmodified":1690875600,
+    "wof:lastmodified":1695886625,
     "wof:name":"Colimes",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/856/875/3/1108568753.geojson
+++ b/data/110/856/875/3/1108568753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053935,
-    "geom:area_square_m":666399359.490418,
+    "geom:area_square_m":666399358.588153,
     "geom:bbox":"-79.60894,-2.368142,-79.13005,-2.177371",
     "geom:latitude":-2.267999,
     "geom:longitude":-79.35961,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"EC.GY.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064406,
-    "wof:geomhash":"79d0f5d809041c66edc28bae10b51006",
+    "wof:geomhash":"c3a6588db9b209621ef0d220433b342b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108568753,
-    "wof:lastmodified":1627522037,
+    "wof:lastmodified":1695886548,
     "wof:name":"Coronel Marcelino Maridue\u00f1a",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/856/881/9/1108568819.geojson
+++ b/data/110/856/881/9/1108568819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011598,
-    "geom:area_square_m":143304600.223077,
+    "geom:area_square_m":143304513.815233,
     "geom:bbox":"-79.1396,-2.284448,-78.970027,-2.135761",
     "geom:latitude":-2.212903,
     "geom:longitude":-79.059328,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.CB.CD",
         "wd:id":"Q2448719"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064409,
-    "wof:geomhash":"8cbb68bf181c0a0c106e4e6f52be1c0c",
+    "wof:geomhash":"ae522793c9c148291c1a88a9f8a82214",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108568819,
-    "wof:lastmodified":1690875599,
+    "wof:lastmodified":1695886625,
     "wof:name":"Cumand\u00e1",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/110/856/890/1/1108568901.geojson
+++ b/data/110/856/890/1/1108568901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026362,
-    "geom:area_square_m":325727166.575082,
+    "geom:area_square_m":325727732.488476,
     "geom:bbox":"-79.884099,-2.331472,-79.679611,-2.084417",
     "geom:latitude":-2.223068,
     "geom:longitude":-79.784512,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.GY.DU",
         "wd:id":"Q2051891"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064412,
-    "wof:geomhash":"cb7b8f507b0a464837963563e3aaae50",
+    "wof:geomhash":"75e9059b232571145c348013961db118",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108568901,
-    "wof:lastmodified":1690875605,
+    "wof:lastmodified":1695886627,
     "wof:name":"Dur\u00e1n",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/856/893/9/1108568939.geojson
+++ b/data/110/856/893/9/1108568939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006312,
-    "geom:area_square_m":77955152.354248,
+    "geom:area_square_m":77955019.216217,
     "geom:bbox":"-78.991806,-2.838984,-78.890505,-2.703373",
     "geom:latitude":-2.76288,
     "geom:longitude":-78.936755,
@@ -104,9 +104,10 @@
         "hasc:id":"EC.CN.DE",
         "wd:id":"Q2466518"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064413,
-    "wof:geomhash":"f9a27ed751797ff52f5ff6c103d7d8fa",
+    "wof:geomhash":"59a4f0276a7302316fcb59524d927c29",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108568939,
-    "wof:lastmodified":1690875600,
+    "wof:lastmodified":1695886625,
     "wof:name":"D\u00e9leg",
     "wof:parent_id":85670909,
     "wof:placetype":"county",

--- a/data/110/856/898/3/1108568983.geojson
+++ b/data/110/856/898/3/1108568983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018668,
-    "geom:area_square_m":230761820.397882,
+    "geom:area_square_m":230761882.262607,
     "geom:bbox":"-79.340775,-1.539807,-79.17384,-1.348964",
     "geom:latitude":-1.453606,
     "geom:longitude":-79.258428,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.BO.EC",
         "wd:id":"Q2466090"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064415,
-    "wof:geomhash":"54da058298d3cbf54521882248c6f158",
+    "wof:geomhash":"71be70c2e81a8e15c4baaadeb171e932",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108568983,
-    "wof:lastmodified":1690875604,
+    "wof:lastmodified":1695886627,
     "wof:name":"Echeand\u00eda",
     "wof:parent_id":85670905,
     "wof:placetype":"county",

--- a/data/110/856/902/5/1108569025.geojson
+++ b/data/110/856/902/5/1108569025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102983,
-    "geom:area_square_m":1273384034.779504,
+    "geom:area_square_m":1273384523.401189,
     "geom:bbox":"-79.755781,-0.591778,-79.398944,-0.055389",
     "geom:latitude":-0.340759,
     "geom:longitude":-79.56124,
@@ -114,9 +114,10 @@
         "hasc:id":"EC.MN.EC",
         "wd:id":"Q1992905"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064416,
-    "wof:geomhash":"dedd8829f368501dfbca9ae98e1f089d",
+    "wof:geomhash":"9c4e361c06518c9ce1e5a123e66adf04",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108569025,
-    "wof:lastmodified":1690875604,
+    "wof:lastmodified":1695886626,
     "wof:name":"El Carmen",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/110/856/905/7/1108569057.geojson
+++ b/data/110/856/905/7/1108569057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.282245,
-    "geom:area_square_m":3489979567.919719,
+    "geom:area_square_m":3489979583.441166,
     "geom:bbox":"-78.190702,-0.518549,-77.250341,0.037147",
     "geom:latitude":-0.249126,
     "geom:longitude":-77.670371,
@@ -119,9 +119,10 @@
         "hasc:id":"EC.NA.EL",
         "wd:id":"Q1989394"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064418,
-    "wof:geomhash":"605218aba361f7f6d8ad144dd9c31d9f",
+    "wof:geomhash":"70eb439bf164bb40e397227f570305e1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108569057,
-    "wof:lastmodified":1690875603,
+    "wof:lastmodified":1695886627,
     "wof:name":"El Chaco",
     "wof:parent_id":85670953,
     "wof:placetype":"county",

--- a/data/110/856/909/5/1108569095.geojson
+++ b/data/110/856/909/5/1108569095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05861,
-    "geom:area_square_m":724616171.822076,
+    "geom:area_square_m":724615834.603785,
     "geom:bbox":"-79.840611,-1.122683,-79.501741,-0.830383",
     "geom:latitude":-0.985689,
     "geom:longitude":-79.657335,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.GY.EE",
         "wd:id":"Q607595"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064419,
-    "wof:geomhash":"0992fbe09db93c3bae4d640c6eb2fa9c",
+    "wof:geomhash":"91f910b955ecfc0aafefbc82a3f1a992",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108569095,
-    "wof:lastmodified":1690875597,
+    "wof:lastmodified":1695886624,
     "wof:name":"El Empalme",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/856/913/5/1108569135.geojson
+++ b/data/110/856/913/5/1108569135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047773,
-    "geom:area_square_m":589817728.414354,
+    "geom:area_square_m":589817954.668579,
     "geom:bbox":"-79.913629,-3.276428,-79.585779,-3.040236",
     "geom:latitude":-3.164603,
     "geom:longitude":-79.777645,
@@ -113,9 +113,10 @@
         "hasc:id":"EC.EO.EG",
         "wd:id":"Q2448730"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064421,
-    "wof:geomhash":"b3e221e0b5177a68bbc16cdbec91b247",
+    "wof:geomhash":"ce15469b3267c4e76d539938879744d4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108569135,
-    "wof:lastmodified":1690875602,
+    "wof:lastmodified":1695886626,
     "wof:name":"El Guabo",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/110/856/917/1/1108569171.geojson
+++ b/data/110/856/917/1/1108569171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010798,
-    "geom:area_square_m":133353285.188404,
+    "geom:area_square_m":133353385.647046,
     "geom:bbox":"-78.707176,-2.933647,-78.581125,-2.749472",
     "geom:latitude":-2.856517,
     "geom:longitude":-78.654424,
@@ -104,9 +104,10 @@
         "hasc:id":"EC.AZ.EP",
         "wd:id":"Q2449110"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064422,
-    "wof:geomhash":"348aa9159b90d78d2f66e3d9183b5b0e",
+    "wof:geomhash":"1a06d6a661d96cf788314239e3a41423",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108569171,
-    "wof:lastmodified":1690875606,
+    "wof:lastmodified":1695886627,
     "wof:name":"El Pan",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/110/856/920/9/1108569209.geojson
+++ b/data/110/856/920/9/1108569209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049414,
-    "geom:area_square_m":609796658.420705,
+    "geom:area_square_m":609796700.730921,
     "geom:bbox":"-78.698111,-3.713581,-78.36667,-3.526339",
     "geom:latitude":-3.61963,
     "geom:longitude":-78.535596,
@@ -104,9 +104,10 @@
         "hasc:id":"EC.ZC.EP",
         "wd:id":"Q1990054"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064424,
-    "wof:geomhash":"b0e7f05d30943d9a123ee589740370fd",
+    "wof:geomhash":"7250077d8347827891e304cd32ba38cb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108569209,
-    "wof:lastmodified":1690875605,
+    "wof:lastmodified":1695886627,
     "wof:name":"El Pangui",
     "wof:parent_id":85670895,
     "wof:placetype":"county",

--- a/data/110/856/924/5/1108569245.geojson
+++ b/data/110/856/924/5/1108569245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005394,
-    "geom:area_square_m":66629576.728017,
+    "geom:area_square_m":66629845.015597,
     "geom:bbox":"-78.982653,-2.533822,-78.853265,-2.430473",
     "geom:latitude":-2.489466,
     "geom:longitude":-78.914009,
@@ -113,9 +113,10 @@
         "hasc:id":"EC.CN.ET",
         "wd:id":"Q2466637"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064425,
-    "wof:geomhash":"060a2f102e768bc49bd8b1c93f8518b4",
+    "wof:geomhash":"98f5d765bce57f3507932c2251d6c75a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108569245,
-    "wof:lastmodified":1690875601,
+    "wof:lastmodified":1695886626,
     "wof:name":"El Tambo",
     "wof:parent_id":85670909,
     "wof:placetype":"county",

--- a/data/110/856/928/7/1108569287.geojson
+++ b/data/110/856/928/7/1108569287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.337878,
-    "geom:area_square_m":4177538216.41086,
+    "geom:area_square_m":4177538216.411426,
     "geom:bbox":"-79.2994863164,0.376732025152,-78.5496787406,1.361055613",
     "geom:latitude":0.757893,
     "geom:longitude":-78.949449,
@@ -121,9 +121,10 @@
     "wof:concordances":{
         "hasc:id":"EC.ES.EA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064426,
-    "wof:geomhash":"7c0a9b27583760d7f2625aa3926a291f",
+    "wof:geomhash":"655b0bdb88beb9afefc9021b2df5dc35",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108569287,
-    "wof:lastmodified":1566584326,
+    "wof:lastmodified":1695886627,
     "wof:name":"Eloy Alfaro",
     "wof:parent_id":85670963,
     "wof:placetype":"county",

--- a/data/110/856/931/7/1108569317.geojson
+++ b/data/110/856/931/7/1108569317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.224074,
-    "geom:area_square_m":2770425119.328892,
+    "geom:area_square_m":2770425895.587927,
     "geom:bbox":"-79.834555,0.569011,-79.11824,1.083639",
     "geom:latitude":0.823952,
     "geom:longitude":-79.471461,
@@ -125,9 +125,10 @@
         "hasc:id":"EC.ES.ES",
         "wd:id":"Q2448307"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064428,
-    "wof:geomhash":"4bedbbb8fe5e5c4e6e3b190a79ff5abe",
+    "wof:geomhash":"29b28a414b49f4d00f1f944187c3d5bb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108569317,
-    "wof:lastmodified":1690875597,
+    "wof:lastmodified":1695886624,
     "wof:name":"Esmeraldas",
     "wof:parent_id":85670963,
     "wof:placetype":"county",

--- a/data/110/856/937/9/1108569379.geojson
+++ b/data/110/856/937/9/1108569379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04256,
-    "geom:area_square_m":524601135.932037,
+    "geom:area_square_m":524600844.287395,
     "geom:bbox":"-79.508646,-4.744841,-79.303723,-4.396091",
     "geom:latitude":-4.54555,
     "geom:longitude":-79.410234,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.LJ.ES",
         "wd:id":"Q1989947"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064430,
-    "wof:geomhash":"b3ba20cd043d40e38befa14b6ae13983",
+    "wof:geomhash":"bfdc5efc86c8593a38033a652f0dde05",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108569379,
-    "wof:lastmodified":1690875598,
+    "wof:lastmodified":1695886625,
     "wof:name":"Esp\u00edndola",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/110/856/941/9/1108569419.geojson
+++ b/data/110/856/941/9/1108569419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110519,
-    "geom:area_square_m":1366567857.985247,
+    "geom:area_square_m":1366567947.574471,
     "geom:bbox":"-80.04912,-0.548015,-79.608469,-0.097159",
     "geom:latitude":-0.324003,
     "geom:longitude":-79.816626,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.MN.FA",
         "wd:id":"Q931546"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064431,
-    "wof:geomhash":"2dd87300c187014366174409b88a7cec",
+    "wof:geomhash":"e54d68e355084c8433d8bba06bcf1068",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108569419,
-    "wof:lastmodified":1690875601,
+    "wof:lastmodified":1695886625,
     "wof:name":"Flavio Alfaro",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/110/856/944/3/1108569443.geojson
+++ b/data/110/856/944/3/1108569443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012137,
-    "geom:area_square_m":149976714.046619,
+    "geom:area_square_m":149976231.734571,
     "geom:bbox":"-79.28309,-2.205023,-79.111589,-2.088718",
     "geom:latitude":-2.155779,
     "geom:longitude":-79.201152,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.GY.GE",
         "wd:id":"Q1990118"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064433,
-    "wof:geomhash":"decf3b5700746d6ddd604497f357b875",
+    "wof:geomhash":"6c8fb2f7444e6a9a5a37830b9b9fc6ff",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108569443,
-    "wof:lastmodified":1690875606,
+    "wof:lastmodified":1695886627,
     "wof:name":"General Antonio Elizalde",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/856/949/1/1108569491.geojson
+++ b/data/110/856/949/1/1108569491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029115,
-    "geom:area_square_m":359463702.597517,
+    "geom:area_square_m":359463845.261718,
     "geom:bbox":"-79.30747,-3.287012,-79.016738,-3.050503",
     "geom:latitude":-3.176621,
     "geom:longitude":-79.158295,
@@ -113,9 +113,10 @@
         "hasc:id":"EC.AZ.GR",
         "wd:id":"Q2466073"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064434,
-    "wof:geomhash":"564b10f8b8e52c75fb5086195e92a4f0",
+    "wof:geomhash":"903dc1ce7cd81aac8c799a8b4dbb05d6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108569491,
-    "wof:lastmodified":1690875601,
+    "wof:lastmodified":1695886626,
     "wof:name":"Gir\u00f3n",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/110/856/956/5/1108569565.geojson
+++ b/data/110/856/956/5/1108569565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056921,
-    "geom:area_square_m":701984676.496809,
+    "geom:area_square_m":701984827.305657,
     "geom:bbox":"-79.603759,-4.327885,-79.320391,-3.998489",
     "geom:latitude":-4.156997,
     "geom:longitude":-79.454359,
@@ -104,9 +104,10 @@
         "hasc:id":"EC.LJ.GO",
         "wd:id":"Q628740"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064437,
-    "wof:geomhash":"c232e3f42d368a2f1fb5a5c3502e72a4",
+    "wof:geomhash":"d1a99c1a4c3e0685920d8257d02e071b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108569565,
-    "wof:lastmodified":1690875603,
+    "wof:lastmodified":1695886626,
     "wof:name":"Gonzanam\u00e1",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/110/856/960/3/1108569603.geojson
+++ b/data/110/856/960/3/1108569603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029754,
-    "geom:area_square_m":367438096.478281,
+    "geom:area_square_m":367438356.177698,
     "geom:bbox":"-78.914849,-3.026298,-78.627373,-2.806158",
     "geom:latitude":-2.919974,
     "geom:longitude":-78.771982,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.AZ.GL",
         "wd:id":"Q2466629"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064439,
-    "wof:geomhash":"7a7f7879fccfbd5051d03bf2a9e171ea",
+    "wof:geomhash":"77dc58ea40c013f25eb4694ba0d2b929",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108569603,
-    "wof:lastmodified":1690875603,
+    "wof:lastmodified":1695886626,
     "wof:name":"Gualaceo",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/110/856/964/1/1108569641.geojson
+++ b/data/110/856/964/1/1108569641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.179994,
-    "geom:area_square_m":2221824306.710564,
+    "geom:area_square_m":2221824020.322584,
     "geom:bbox":"-78.949525,-3.584404,-78.340037,-3.063066",
     "geom:latitude":-3.361382,
     "geom:longitude":-78.651764,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.MS.GU",
         "wd:id":"Q1990498"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064440,
-    "wof:geomhash":"96d9a5b9b0588d362353968ecfbc90ad",
+    "wof:geomhash":"7c24e8c4ae0fd76d25ff40710e20b5bd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108569641,
-    "wof:lastmodified":1690875598,
+    "wof:lastmodified":1695886625,
     "wof:name":"Gualaquiza",
     "wof:parent_id":85670935,
     "wof:placetype":"county",

--- a/data/110/856/977/5/1108569775.geojson
+++ b/data/110/856/977/5/1108569775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169231,
-    "geom:area_square_m":2091422456.044509,
+    "geom:area_square_m":2091422382.159019,
     "geom:bbox":"-78.488577,-2.124297,-77.77279,-1.61982",
     "geom:latitude":-1.894533,
     "geom:longitude":-78.170022,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.MS.HB",
         "wd:id":"Q1992987"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064445,
-    "wof:geomhash":"5e927b0621b952603249348d3bd12fe5",
+    "wof:geomhash":"974e65a4e378d6408acfcfbadf16a391",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108569775,
-    "wof:lastmodified":1690875600,
+    "wof:lastmodified":1695886626,
     "wof:name":"Huamboya",
     "wof:parent_id":85670935,
     "wof:placetype":"county",

--- a/data/110/856/981/9/1108569819.geojson
+++ b/data/110/856/981/9/1108569819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005275,
-    "geom:area_square_m":65111260.939137,
+    "geom:area_square_m":65111448.002515,
     "geom:bbox":"-80.245001,-3.502358,-80.118805,-3.417944",
     "geom:latitude":-3.461003,
     "geom:longitude":-80.185166,
@@ -113,9 +113,10 @@
         "hasc:id":"EC.EO.HU",
         "wd:id":"Q940256"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064446,
-    "wof:geomhash":"08acf51da2078485be4a142242a77053",
+    "wof:geomhash":"d68eead9b0aba61eb5b099e05b094b08",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108569819,
-    "wof:lastmodified":1690875606,
+    "wof:lastmodified":1695886628,
     "wof:name":"Huaquillas",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/110/856/988/1/1108569881.geojson
+++ b/data/110/856/988/1/1108569881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.436371,
-    "geom:area_square_m":5395494146.353027,
+    "geom:area_square_m":5395494225.730176,
     "geom:bbox":"-91.662941,-1.052139,-90.781219,0.166639",
     "geom:latitude":-0.536158,
     "geom:longitude":-91.224946,
@@ -134,9 +134,10 @@
         "hasc:id":"EC.GA.IS",
         "wd:id":"Q14920554"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064448,
-    "wof:geomhash":"582b178c8ab403f51f8377690c477246",
+    "wof:geomhash":"fe64dbab263cd515543654b87176558e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108569881,
-    "wof:lastmodified":1690875606,
+    "wof:lastmodified":1695886045,
     "wof:name":"Isabela",
     "wof:parent_id":85670899,
     "wof:placetype":"county",

--- a/data/110/856/992/3/1108569923.geojson
+++ b/data/110/856/992/3/1108569923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117019,
-    "geom:area_square_m":1446501016.178145,
+    "geom:area_square_m":1446501575.748412,
     "geom:bbox":"-80.778117,-1.85526,-80.41421,-1.173925",
     "geom:latitude":-1.438559,
     "geom:longitude":-80.588774,
@@ -128,9 +128,10 @@
         "hasc:id":"EC.MN.JJ",
         "wd:id":"Q1990149"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064450,
-    "wof:geomhash":"3c2d85e73c5b999ba57aa0c8eeafaec8",
+    "wof:geomhash":"3309afdc15de0f9750b9d627c89acca0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108569923,
-    "wof:lastmodified":1690875602,
+    "wof:lastmodified":1695886045,
     "wof:name":"Jipijapa",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/110/856/998/3/1108569983.geojson
+++ b/data/110/856/998/3/1108569983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020643,
-    "geom:area_square_m":255222963.869768,
+    "geom:area_square_m":255222751.207855,
     "geom:bbox":"-80.293655,-1.019114,-80.062536,-0.855988",
     "geom:latitude":-0.939903,
     "geom:longitude":-80.189678,
@@ -116,9 +116,10 @@
         "hasc:id":"EC.MN.JN",
         "wd:id":"Q1992882"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064452,
-    "wof:geomhash":"b4b2c02d4d5edf1a8ad51a54719de02b",
+    "wof:geomhash":"40e378dcf96d8f3abc2ed38e198c5806",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108569983,
-    "wof:lastmodified":1690875598,
+    "wof:lastmodified":1695886625,
     "wof:name":"Jun\u00edn",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/110/857/001/1/1108570011.geojson
+++ b/data/110/857/001/1/1108570011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024926,
-    "geom:area_square_m":307541586.705279,
+    "geom:area_square_m":307541320.77231,
     "geom:bbox":"-80.187649,-3.892187,-79.965879,-3.706559",
     "geom:latitude":-3.80337,
     "geom:longitude":-80.06514,
@@ -116,9 +116,10 @@
         "hasc:id":"EC.EO.LL",
         "wd:id":"Q1989281"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064458,
-    "wof:geomhash":"0a3021390462386fb6968a2e1dd3eb7e",
+    "wof:geomhash":"9b0248981de2d23a006eedb4b8e5f545",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108570011,
-    "wof:lastmodified":1690875589,
+    "wof:lastmodified":1695886043,
     "wof:name":"Las Lajas",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/110/857/003/3/1108570033.geojson
+++ b/data/110/857/003/3/1108570033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012233,
-    "geom:area_square_m":151220719.670967,
+    "geom:area_square_m":151220881.777654,
     "geom:bbox":"-79.390141,-1.354192,-79.192912,-1.201094",
     "geom:latitude":-1.284734,
     "geom:longitude":-79.289398,
@@ -119,9 +119,10 @@
         "hasc:id":"EC.BO.LN",
         "wd:id":"Q2466646"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064459,
-    "wof:geomhash":"4762515929ddb7110a4b8763da6a92f7",
+    "wof:geomhash":"91602deb2f15190646ff76402fb7c1a3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108570033,
-    "wof:lastmodified":1690875593,
+    "wof:lastmodified":1695886623,
     "wof:name":"Las Naves",
     "wof:parent_id":85670905,
     "wof:placetype":"county",

--- a/data/110/857/011/7/1108570117.geojson
+++ b/data/110/857/011/7/1108570117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044504,
-    "geom:area_square_m":549977497.930195,
+    "geom:area_square_m":549977497.929741,
     "geom:bbox":"-80.266599652,-2.10782804488,-80.0490667887,-1.73440610035",
     "geom:latitude":-1.948183,
     "geom:longitude":-80.151914,
@@ -92,9 +92,10 @@
         "hasc:id":"EC.GY.LS",
         "wd:id":"Q1990032"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064462,
-    "wof:geomhash":"09ef5ef8e14ec0522251ec8514dc2310",
+    "wof:geomhash":"5948043c7e3a691da7345e58263f7e4c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108570117,
-    "wof:lastmodified":1566584312,
+    "wof:lastmodified":1695886623,
     "wof:name":"Lomas de Sargentillo",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/857/021/7/1108570217.geojson
+++ b/data/110/857/021/7/1108570217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029681,
-    "geom:area_square_m":366400415.884003,
+    "geom:area_square_m":366400206.050056,
     "geom:bbox":"-80.032974,-3.433741,-79.838025,-3.165663",
     "geom:latitude":-3.307936,
     "geom:longitude":-79.941234,
@@ -116,9 +116,10 @@
         "hasc:id":"EC.EO.MC",
         "wd:id":"Q2448795"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064466,
-    "wof:geomhash":"822a975996f586c4d79c9d50927c29c2",
+    "wof:geomhash":"938d18118a334f60dc84d9404fc572a8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108570217,
-    "wof:lastmodified":1690875593,
+    "wof:lastmodified":1695886043,
     "wof:name":"Machala",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/110/857/027/3/1108570273.geojson
+++ b/data/110/857/027/3/1108570273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011083,
-    "geom:area_square_m":136744835.642404,
+    "geom:area_square_m":136744898.383641,
     "geom:bbox":"-79.994145,-3.840961,-79.851737,-3.70725",
     "geom:latitude":-3.778063,
     "geom:longitude":-79.928396,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.EO.MR",
         "wd:id":"Q1988800"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064468,
-    "wof:geomhash":"34b9177ca117c8ac80ee5a069aa81e8b",
+    "wof:geomhash":"c4bf6ab6c1a43d5793b243b7c95f13bf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108570273,
-    "wof:lastmodified":1690875592,
+    "wof:lastmodified":1695886623,
     "wof:name":"Marcabel\u00ed",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/110/857/038/1/1108570381.geojson
+++ b/data/110/857/038/1/1108570381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006932,
-    "geom:area_square_m":85684357.723317,
+    "geom:area_square_m":85684592.391041,
     "geom:bbox":"-78.764689,-1.468167,-78.608915,-1.35412",
     "geom:latitude":-1.415104,
     "geom:longitude":-78.694582,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.TU.MO",
         "wd:id":"Q3656170"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064473,
-    "wof:geomhash":"80547ffc53d9bd90c6b1a66331ee9e3b",
+    "wof:geomhash":"9f04cb08aa242364c2c69fae20c872a6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108570381,
-    "wof:lastmodified":1690875588,
+    "wof:lastmodified":1695886622,
     "wof:name":"Mocha",
     "wof:parent_id":85670959,
     "wof:placetype":"county",

--- a/data/110/857/042/9/1108570429.geojson
+++ b/data/110/857/042/9/1108570429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029793,
-    "geom:area_square_m":368214703.27922,
+    "geom:area_square_m":368214590.856454,
     "geom:bbox":"-79.458997,-1.934376,-79.195276,-1.664266",
     "geom:latitude":-1.803174,
     "geom:longitude":-79.315303,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.LR.MN",
         "wd:id":"Q1990411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064475,
-    "wof:geomhash":"d271ca12647219bbb5deba590427e585",
+    "wof:geomhash":"04e79f1a1868c9ed48f5b7dbe359a54e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108570429,
-    "wof:lastmodified":1690875592,
+    "wof:lastmodified":1695886623,
     "wof:name":"Montalvo",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/110/857/047/1/1108570471.geojson
+++ b/data/110/857/047/1/1108570471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068405,
-    "geom:area_square_m":845681390.838327,
+    "geom:area_square_m":845681294.617907,
     "geom:bbox":"-80.883743,-1.286501,-80.51604,-0.927058",
     "geom:latitude":-1.106535,
     "geom:longitude":-80.684102,
@@ -119,9 +119,10 @@
         "hasc:id":"EC.MN.MO",
         "wd:id":"Q2466536"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064476,
-    "wof:geomhash":"86e408f94ea5e364ab16b2bd3094ad30",
+    "wof:geomhash":"28f6e3b603cd7fb658654d72ccf62e40",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108570471,
-    "wof:lastmodified":1690875588,
+    "wof:lastmodified":1695886621,
     "wof:name":"Montecristi",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/110/857/062/7/1108570627.geojson
+++ b/data/110/857/062/7/1108570627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.172839,
-    "geom:area_square_m":2131080482.549419,
+    "geom:area_square_m":2131080328.231375,
     "geom:bbox":"-78.951692,-4.680606,-78.529435,-3.947781",
     "geom:latitude":-4.32771,
     "geom:longitude":-78.753709,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.ZC.NA",
         "wd:id":"Q1989193"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064482,
-    "wof:geomhash":"74357a305b843796290c1c249a3fcc9b",
+    "wof:geomhash":"3c24a32e6eeceaa678277062364e2cdb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108570627,
-    "wof:lastmodified":1690875588,
+    "wof:lastmodified":1695886622,
     "wof:name":"Nangaritza",
     "wof:parent_id":85670895,
     "wof:placetype":"county",

--- a/data/110/857/068/7/1108570687.geojson
+++ b/data/110/857/068/7/1108570687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018513,
-    "geom:area_square_m":228749661.89099,
+    "geom:area_square_m":228750136.727382,
     "geom:bbox":"-79.499111,-2.225552,-79.274679,-2.082247",
     "geom:latitude":-2.151173,
     "geom:longitude":-79.395891,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.GY.NT",
         "wd:id":"Q1990400"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064484,
-    "wof:geomhash":"e849595c2868b6f849a0385b386edc20",
+    "wof:geomhash":"ee79c323386cbcb345ee2d301832f3b1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108570687,
-    "wof:lastmodified":1690875595,
+    "wof:lastmodified":1695886624,
     "wof:name":"Naranjito",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/857/070/3/1108570703.geojson
+++ b/data/110/857/070/3/1108570703.geojson
@@ -50,7 +50,7 @@
         }
     ],
     "wof:id":1108570703,
-    "wof:lastmodified":1694492370,
+    "wof:lastmodified":1695886621,
     "wof:name":"",
     "wof:parent_id":85670909,
     "wof:placetype":"county",

--- a/data/110/857/072/3/1108570723.geojson
+++ b/data/110/857/072/3/1108570723.geojson
@@ -50,7 +50,7 @@
         }
     ],
     "wof:id":1108570723,
-    "wof:lastmodified":1694492371,
+    "wof:lastmodified":1695886623,
     "wof:name":"",
     "wof:parent_id":85670971,
     "wof:placetype":"county",

--- a/data/110/857/074/1/1108570741.geojson
+++ b/data/110/857/074/1/1108570741.geojson
@@ -50,7 +50,7 @@
         }
     ],
     "wof:id":1108570741,
-    "wof:lastmodified":1694492371,
+    "wof:lastmodified":1695886623,
     "wof:name":"",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/110/857/075/9/1108570759.geojson
+++ b/data/110/857/075/9/1108570759.geojson
@@ -50,7 +50,7 @@
         }
     ],
     "wof:id":1108570759,
-    "wof:lastmodified":1694492371,
+    "wof:lastmodified":1695886623,
     "wof:name":"",
     "wof:parent_id":85670983,
     "wof:placetype":"county",

--- a/data/110/857/085/3/1108570853.geojson
+++ b/data/110/857/085/3/1108570853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0238,
-    "geom:area_square_m":293752422.455822,
+    "geom:area_square_m":293752387.924154,
     "geom:bbox":"-79.272489,-3.623347,-79.038619,-3.359443",
     "geom:latitude":-3.486195,
     "geom:longitude":-79.129011,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.AZ.ON",
         "wd:id":"Q2466440"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064491,
-    "wof:geomhash":"13e1dfdf39f1cac8947c81649c3cdfba",
+    "wof:geomhash":"e1ba5b7fa2e1e676c7d35cd16db10b6d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108570853,
-    "wof:lastmodified":1690875587,
+    "wof:lastmodified":1695886621,
     "wof:name":"O\u00f1a",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/110/857/091/5/1108570915.geojson
+++ b/data/110/857/091/5/1108570915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045607,
-    "geom:area_square_m":563792343.417668,
+    "geom:area_square_m":563792686.299634,
     "geom:bbox":"-79.846804,-1.486634,-79.565937,-1.176051",
     "geom:latitude":-1.329432,
     "geom:longitude":-79.713384,
@@ -104,9 +104,10 @@
         "hasc:id":"EC.LR.PA",
         "wd:id":"Q1990986"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064493,
-    "wof:geomhash":"6e5b4f58c93a23cf6b6ac06d95918c5e",
+    "wof:geomhash":"8e8d807562c0e0bee7df8227c3873851",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108570915,
-    "wof:lastmodified":1690875588,
+    "wof:lastmodified":1695886622,
     "wof:name":"Palenque",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/110/857/095/5/1108570955.geojson
+++ b/data/110/857/095/5/1108570955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015289,
-    "geom:area_square_m":188970391.543833,
+    "geom:area_square_m":188970293.888876,
     "geom:bbox":"-80.01459,-1.716567,-79.852641,-1.536675",
     "geom:latitude":-1.635019,
     "geom:longitude":-79.917927,
@@ -110,9 +110,10 @@
         "hasc:id":"EC.GY.PA",
         "wd:id":"Q1990111"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064495,
-    "wof:geomhash":"c2228de969ff3f7897092d7a735f1093",
+    "wof:geomhash":"2620dc283bfbef287c2177ddd0f12dbd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108570955,
-    "wof:lastmodified":1690875594,
+    "wof:lastmodified":1695886624,
     "wof:name":"Palestina",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/857/100/1/1108571001.geojson
+++ b/data/110/857/100/1/1108571001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031384,
-    "geom:area_square_m":387834265.260908,
+    "geom:area_square_m":387834733.360157,
     "geom:bbox":"-79.033491,-2.115873,-78.808255,-1.912436",
     "geom:latitude":-2.013989,
     "geom:longitude":-78.92799,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.CB.PA",
         "wd:id":"Q930902"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064497,
-    "wof:geomhash":"ffff7eaeb49e7640099a87036e53eaac",
+    "wof:geomhash":"0e4ea7d8b28c1816e31f4a8568da7138",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108571001,
-    "wof:lastmodified":1690875591,
+    "wof:lastmodified":1695886622,
     "wof:name":"Pallatanga",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/110/857/106/1/1108571061.geojson
+++ b/data/110/857/106/1/1108571061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103778,
-    "geom:area_square_m":1280104459.832741,
+    "geom:area_square_m":1280104687.103322,
     "geom:bbox":"-79.996966,-4.180583,-79.511138,-3.819959",
     "geom:latitude":-4.004092,
     "geom:longitude":-79.74399,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.LJ.PA",
         "wd:id":"Q1990006"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064499,
-    "wof:geomhash":"fca958af41526f7ff5ff97b5cfb969a4",
+    "wof:geomhash":"fc05f47e96ca4d17d485b1c73fc444b2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108571061,
-    "wof:lastmodified":1690875591,
+    "wof:lastmodified":1695886623,
     "wof:name":"Paltas",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/110/857/110/1/1108571101.geojson
+++ b/data/110/857/110/1/1108571101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057904,
-    "geom:area_square_m":715865240.076224,
+    "geom:area_square_m":715865823.885485,
     "geom:bbox":"-79.335379,-1.215581,-78.930158,-0.979444",
     "geom:latitude":-1.096883,
     "geom:longitude":-79.148081,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.CT.PA",
         "wd:id":"Q2066697"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064500,
-    "wof:geomhash":"07f03b3a67fabad0fd35785d697caf8e",
+    "wof:geomhash":"eeda21c9469e0707873cd36e7a39f0e7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108571101,
-    "wof:lastmodified":1690875591,
+    "wof:lastmodified":1695886622,
     "wof:name":"Pangua",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/110/857/118/5/1108571185.geojson
+++ b/data/110/857/118/5/1108571185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026524,
-    "geom:area_square_m":327891561.367035,
+    "geom:area_square_m":327891489.036299,
     "geom:bbox":"-78.51955,-1.402234,-78.321963,-1.152061",
     "geom:latitude":-1.264489,
     "geom:longitude":-78.423565,
@@ -113,9 +113,10 @@
         "hasc:id":"EC.TU.PA",
         "wd:id":"Q3656217"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064504,
-    "wof:geomhash":"db72dd9040dcc03a4ac09f75414f166a",
+    "wof:geomhash":"ed42a93862bf82c54e230e77d464f0f2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108571185,
-    "wof:lastmodified":1690875590,
+    "wof:lastmodified":1695886622,
     "wof:name":"Patate",
     "wof:parent_id":85670959,
     "wof:placetype":"county",

--- a/data/110/857/125/1/1108571251.geojson
+++ b/data/110/857/125/1/1108571251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153249,
-    "geom:area_square_m":1894946546.796096,
+    "geom:area_square_m":1894946495.201228,
     "geom:bbox":"-80.165514,-0.236659,-79.57203,0.370111",
     "geom:latitude":0.088137,
     "geom:longitude":-79.902367,
@@ -138,9 +138,10 @@
         "hasc:id":"EC.MN.PE",
         "wd:id":"Q367954"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064506,
-    "wof:geomhash":"febae89098b59cb4dbc2302df046c288",
+    "wof:geomhash":"5aea7f923ed442ba60e8fb7b82af1f1d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108571251,
-    "wof:lastmodified":1690875596,
+    "wof:lastmodified":1695886045,
     "wof:name":"Pedernales",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/110/857/128/9/1108571289.geojson
+++ b/data/110/857/128/9/1108571289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076457,
-    "geom:area_square_m":944915744.65281,
+    "geom:area_square_m":944915980.349865,
     "geom:bbox":"-80.44464,-2.083886,-80.114514,-1.647733",
     "geom:latitude":-1.848071,
     "geom:longitude":-80.287429,
@@ -104,9 +104,10 @@
         "hasc:id":"EC.GY.PC",
         "wd:id":"Q1990023"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064507,
-    "wof:geomhash":"038687b33672ee4dec288c39e33d1910",
+    "wof:geomhash":"812bddd0353b25fd3f8d334b3468cbf3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108571289,
-    "wof:lastmodified":1690875591,
+    "wof:lastmodified":1695886622,
     "wof:name":"Pedro Carbo",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/857/140/3/1108571403.geojson
+++ b/data/110/857/140/3/1108571403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088233,
-    "geom:area_square_m":1090880907.174057,
+    "geom:area_square_m":1090880787.193014,
     "geom:bbox":"-80.041902,-1.150481,-79.66773,-0.63349",
     "geom:latitude":-0.885299,
     "geom:longitude":-79.841116,
@@ -110,9 +110,10 @@
         "hasc:id":"EC.MN.PI",
         "wd:id":"Q1990121"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064511,
-    "wof:geomhash":"b974da5707837b48e3b1b4ff968cc80e",
+    "wof:geomhash":"2c97943180b6db1362a95abee7b5ad0b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108571403,
-    "wof:lastmodified":1690875597,
+    "wof:lastmodified":1695886045,
     "wof:name":"Pichincha",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/110/857/143/3/1108571433.geojson
+++ b/data/110/857/143/3/1108571433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037984,
-    "geom:area_square_m":469670447.768281,
+    "geom:area_square_m":469670332.475716,
     "geom:bbox":"-78.030276,0.159618,-77.784663,0.432131",
     "geom:latitude":0.287217,
     "geom:longitude":-77.918761,
@@ -104,9 +104,10 @@
         "hasc:id":"EC.IM.PI",
         "wd:id":"Q1528983"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064513,
-    "wof:geomhash":"d4bf5ce9239ab89e6687202e4b0f99fc",
+    "wof:geomhash":"0064f9358e936201ab80492fa8f41416",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108571433,
-    "wof:lastmodified":1690875590,
+    "wof:lastmodified":1695886622,
     "wof:name":"Pimampiro",
     "wof:parent_id":85670971,
     "wof:placetype":"county",

--- a/data/110/857/147/5/1108571475.geojson
+++ b/data/110/857/147/5/1108571475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01714,
-    "geom:area_square_m":211404678.861859,
+    "geom:area_square_m":211404469.377541,
     "geom:bbox":"-80.223417,-4.169344,-80.006493,-4.018993",
     "geom:latitude":-4.090856,
     "geom:longitude":-80.129728,
@@ -98,9 +98,10 @@
         "hasc:id":"EC.LJ.PI",
         "wd:id":"Q1989956"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064514,
-    "wof:geomhash":"b494910d21949773edb21479380347b5",
+    "wof:geomhash":"b48f69b58d262417369e231d7de20597",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108571475,
-    "wof:lastmodified":1690875596,
+    "wof:lastmodified":1695886624,
     "wof:name":"Pindal",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/110/857/160/5/1108571605.geojson
+++ b/data/110/857/160/5/1108571605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068937,
-    "geom:area_square_m":851140601.567276,
+    "geom:area_square_m":851140541.373795,
     "geom:bbox":"-79.758123,-3.325055,-79.407259,-2.968852",
     "geom:latitude":-3.144408,
     "geom:longitude":-79.564482,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.AZ.PU",
         "wd:id":"Q2449080"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064519,
-    "wof:geomhash":"15ba2e6513360dee9c30fd54397b41ca",
+    "wof:geomhash":"54cf7a60caa40c530c9605969f3f1b8e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108571605,
-    "wof:lastmodified":1690875587,
+    "wof:lastmodified":1695886621,
     "wof:name":"Pucar\u00e1",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/110/857/163/1/1108571631.geojson
+++ b/data/110/857/163/1/1108571631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02722,
-    "geom:area_square_m":336457641.274859,
+    "geom:area_square_m":336457641.274739,
     "geom:bbox":"-79.6275233563,-1.69988913878,-79.4831818631,-1.36637380084",
     "geom:latitude":-1.546776,
     "geom:longitude":-79.542566,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"EC.LR.PV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064521,
-    "wof:geomhash":"2dcea4245a2c3eef41df184f13c4587c",
+    "wof:geomhash":"c2f4a8a5b86f8a7a795ad13ee6715ec2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108571631,
-    "wof:lastmodified":1566584310,
+    "wof:lastmodified":1695886622,
     "wof:name":"Pueblo Viejo",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/110/857/174/9/1108571749.geojson
+++ b/data/110/857/174/9/1108571749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050642,
-    "geom:area_square_m":624694093.017594,
+    "geom:area_square_m":624694158.623056,
     "geom:bbox":"-80.293512,-4.074364,-79.881639,-3.854836",
     "geom:latitude":-3.972203,
     "geom:longitude":-80.072143,
@@ -104,9 +104,10 @@
         "hasc:id":"EC.LJ.PU",
         "wd:id":"Q1989981"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064526,
-    "wof:geomhash":"302d8bb149cebb118f83c57218295d41",
+    "wof:geomhash":"214212baeb8b46845b545124d7023ff5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108571749,
-    "wof:lastmodified":1690875589,
+    "wof:lastmodified":1695886622,
     "wof:name":"Puyango",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/110/857/178/5/1108571785.geojson
+++ b/data/110/857/178/5/1108571785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013938,
-    "geom:area_square_m":172297448.978338,
+    "geom:area_square_m":172297379.957395,
     "geom:bbox":"-78.712053,-1.504653,-78.541152,-1.34897",
     "geom:latitude":-1.441981,
     "geom:longitude":-78.616588,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.TU.QU",
         "wd:id":"Q3656241"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064527,
-    "wof:geomhash":"8de60774e3992c251ab517fd423ae5b2",
+    "wof:geomhash":"882e4f92debf79b2b64bcf956db5b275",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108571785,
-    "wof:lastmodified":1690875596,
+    "wof:lastmodified":1695886624,
     "wof:name":"Quero",
     "wof:parent_id":85670959,
     "wof:placetype":"county",

--- a/data/110/857/183/7/1108571837.geojson
+++ b/data/110/857/183/7/1108571837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129999,
-    "geom:area_square_m":1607405140.352733,
+    "geom:area_square_m":1607405140.59908,
     "geom:bbox":"-78.255278,-0.663772,-77.557928,-0.235301",
     "geom:latitude":-0.466589,
     "geom:longitude":-77.972819,
@@ -114,9 +114,10 @@
         "hasc:id":"EC.NA.QU",
         "wd:id":"Q1989112"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064529,
-    "wof:geomhash":"ba5145345ffb110b67790625ac4df9d7",
+    "wof:geomhash":"d9668cf2f97cbddca39d0829009e8fa3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108571837,
-    "wof:lastmodified":1690875596,
+    "wof:lastmodified":1695886624,
     "wof:name":"Quijos",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/857/187/9/1108571879.geojson
+++ b/data/110/857/187/9/1108571879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019533,
-    "geom:area_square_m":240830854.492909,
+    "geom:area_square_m":240830848.730584,
     "geom:bbox":"-79.470235,-4.455985,-79.303449,-4.237541",
     "geom:latitude":-4.340345,
     "geom:longitude":-79.379911,
@@ -98,9 +98,10 @@
         "hasc:id":"EC.LJ.QU",
         "wd:id":"Q627330"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064531,
-    "wof:geomhash":"b652e0176dded58e7f66023ad3968dde",
+    "wof:geomhash":"82c749047fe85c11594f719192664729",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108571879,
-    "wof:lastmodified":1690875590,
+    "wof:lastmodified":1695886622,
     "wof:name":"Quilanga",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/110/857/192/1/1108571921.geojson
+++ b/data/110/857/192/1/1108571921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.299512,
-    "geom:area_square_m":3703427942.634808,
+    "geom:area_square_m":3703428332.621917,
     "geom:bbox":"-79.825136,0.068936,-78.821441,0.685701",
     "geom:latitude":0.394056,
     "geom:longitude":-79.427662,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.ES.QU",
         "wd:id":"Q971410"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064532,
-    "wof:geomhash":"59531637ba3fcc31852125cefb0a7842",
+    "wof:geomhash":"3d7a2264813d36d1e98102495881ceab",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108571921,
-    "wof:lastmodified":1690875586,
+    "wof:lastmodified":1695886621,
     "wof:name":"Quinind\u00e9",
     "wof:parent_id":85670963,
     "wof:placetype":"county",

--- a/data/110/857/207/3/1108572073.geojson
+++ b/data/110/857/207/3/1108572073.geojson
@@ -113,7 +113,7 @@
         }
     ],
     "wof:id":1108572073,
-    "wof:lastmodified":1694492371,
+    "wof:lastmodified":1695886623,
     "wof:name":"San Jacinto de Yaguac",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/857/207/3/1108572073.geojson
+++ b/data/110/857/207/3/1108572073.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"EC.GY.YA",
         "wd:id":"Q1990029"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064542,
     "wof:geomhash":"bb2131293c5df6bc510d70dd2bbbd327",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108572073,
-    "wof:lastmodified":1695886623,
+    "wof:lastmodified":1696023152,
     "wof:name":"San Jacinto de Yaguac",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/857/209/7/1108572097.geojson
+++ b/data/110/857/209/7/1108572097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078228,
-    "geom:area_square_m":965731991.993866,
+    "geom:area_square_m":965731672.824797,
     "geom:bbox":"-78.657896,-3.509989,-78.125369,-3.031607",
     "geom:latitude":-3.261372,
     "geom:longitude":-78.381818,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.MS.SJ",
         "wd:id":"Q1990469"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064544,
-    "wof:geomhash":"7b9453a69357528aa80bf2386c519501",
+    "wof:geomhash":"7136f32d2d2ff7346e0c61fb9bd31a31",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108572097,
-    "wof:lastmodified":1690875594,
+    "wof:lastmodified":1695886624,
     "wof:name":"San Juan Bosco",
     "wof:parent_id":85670935,
     "wof:placetype":"county",

--- a/data/110/857/217/9/1108572179.geojson
+++ b/data/110/857/217/9/1108572179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015879,
-    "geom:area_square_m":196346146.996347,
+    "geom:area_square_m":196346269.38765,
     "geom:bbox":"-79.303801,-0.110324,-79.103775,0.013553",
     "geom:latitude":-0.050007,
     "geom:longitude":-79.211113,
@@ -52,9 +52,10 @@
     "wof:concordances":{
         "hasc:id":"EC.PI.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064547,
-    "wof:geomhash":"c40cd9e7079a30dbc7538abe70402813",
+    "wof:geomhash":"18d2cc7092df4ca2f4d378c4db28bf36",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -64,7 +65,7 @@
         }
     ],
     "wof:id":1108572179,
-    "wof:lastmodified":1627522037,
+    "wof:lastmodified":1695886548,
     "wof:name":"San Miguel de los Bancos",
     "wof:parent_id":85670983,
     "wof:placetype":"county",

--- a/data/110/857/225/9/1108572259.geojson
+++ b/data/110/857/225/9/1108572259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046219,
-    "geom:area_square_m":571223305.623016,
+    "geom:area_square_m":571222975.804411,
     "geom:bbox":"-79.250751,-1.934987,-78.871511,-1.685559",
     "geom:latitude":-1.791721,
     "geom:longitude":-79.10043,
@@ -131,9 +131,10 @@
         "hasc:id":"EC.BO.SM",
         "wd:id":"Q2466528"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064549,
-    "wof:geomhash":"eee5c6f776ab7084d459f4538647bfb0",
+    "wof:geomhash":"05026af91d34f423c545a9102a274aa7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108572259,
-    "wof:lastmodified":1690875593,
+    "wof:lastmodified":1695886044,
     "wof:name":"San Miguel",
     "wof:parent_id":85670905,
     "wof:placetype":"county",

--- a/data/110/857/228/9/1108572289.geojson
+++ b/data/110/857/228/9/1108572289.geojson
@@ -116,7 +116,7 @@
         }
     ],
     "wof:id":1108572289,
-    "wof:lastmodified":1694492370,
+    "wof:lastmodified":1695886621,
     "wof:name":"San Pedro de Pelileo",
     "wof:parent_id":85670959,
     "wof:placetype":"county",

--- a/data/110/857/228/9/1108572289.geojson
+++ b/data/110/857/228/9/1108572289.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"EC.TU.PE",
         "wd:id":"Q3656220"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064551,
     "wof:geomhash":"110ca78c4355649d2ef70174fb6adc0a",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108572289,
-    "wof:lastmodified":1695886621,
+    "wof:lastmodified":1696023150,
     "wof:name":"San Pedro de Pelileo",
     "wof:parent_id":85670959,
     "wof:placetype":"county",

--- a/data/110/857/234/9/1108572349.geojson
+++ b/data/110/857/234/9/1108572349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026923,
-    "geom:area_square_m":332828611.447017,
+    "geom:area_square_m":332828176.141726,
     "geom:bbox":"-77.969381,-1.365972,-77.730659,-1.16145",
     "geom:latitude":-1.272864,
     "geom:longitude":-77.862366,
@@ -113,9 +113,10 @@
         "hasc:id":"EC.PA.SC",
         "wd:id":"Q1992910"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064553,
-    "wof:geomhash":"ad13b50e9619edcc2fdbda49e3c9becf",
+    "wof:geomhash":"f3a8a6b1a98072e8e92301f4403a2898",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108572349,
-    "wof:lastmodified":1690875589,
+    "wof:lastmodified":1695886622,
     "wof:name":"Santa Clara",
     "wof:parent_id":85670949,
     "wof:placetype":"county",

--- a/data/110/857/240/1/1108572401.geojson
+++ b/data/110/857/240/1/1108572401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.299623,
-    "geom:area_square_m":3702323901.552818,
+    "geom:area_square_m":3702323901.552258,
     "geom:bbox":"-80.887391,-2.503434,-80.225604,-1.652626",
     "geom:latitude":-2.128767,
     "geom:longitude":-80.566985,
@@ -129,12 +129,13 @@
         "hasc:id":"EC.SE.SE",
         "wd:id":"Q1992974"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85670979
     ],
     "wof:country":"EC",
     "wof:created":1474064555,
-    "wof:geomhash":"489b0772aa292fe77f0634da0923e03b",
+    "wof:geomhash":"316dc0a57574e6993abd062de91f8a32",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108572401,
-    "wof:lastmodified":1690875593,
+    "wof:lastmodified":1695886044,
     "wof:name":"Santa Elena",
     "wof:parent_id":85670979,
     "wof:placetype":"county",

--- a/data/110/857/247/9/1108572479.geojson
+++ b/data/110/857/247/9/1108572479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028851,
-    "geom:area_square_m":356588277.763328,
+    "geom:area_square_m":356588277.763437,
     "geom:bbox":"-80.1680569039,-1.79155156816,-79.8884516971,-1.62777481384",
     "geom:latitude":-1.711591,
     "geom:longitude":-80.032798,
@@ -112,9 +112,10 @@
     "wof:concordances":{
         "hasc:id":"EC.GU.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064558,
-    "wof:geomhash":"e297f2fcccb199f8611cc1d8647a63f2",
+    "wof:geomhash":"181cd41a58cf1bfa5f0f565d6609e11a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108572479,
-    "wof:lastmodified":1566584313,
+    "wof:lastmodified":1695886623,
     "wof:name":"Santa Lucia",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/857/251/9/1108572519.geojson
+++ b/data/110/857/251/9/1108572519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069486,
-    "geom:area_square_m":857643241.859167,
+    "geom:area_square_m":857643893.095416,
     "geom:bbox":"-80.307653,-3.629073,-79.760906,-3.204639",
     "geom:latitude":-3.449822,
     "geom:longitude":-79.972816,
@@ -137,9 +137,10 @@
         "hasc:id":"EC.EO.SR",
         "wd:id":"Q1989250"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064560,
-    "wof:geomhash":"958bc41cf8e31b9f444874be50f5716d",
+    "wof:geomhash":"6c9cabb427693a98b7f4f632ef24a467",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108572519,
-    "wof:lastmodified":1690875589,
+    "wof:lastmodified":1695886044,
     "wof:name":"Santa Rosa",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/110/857/255/7/1108572557.geojson
+++ b/data/110/857/255/7/1108572557.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"EC.TU.PI",
         "wd:id":"Q3656240"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064561,
     "wof:geomhash":"70cf13d82ceb2d62f19620ab50db1ee0",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108572557,
-    "wof:lastmodified":1695886624,
+    "wof:lastmodified":1696023152,
     "wof:name":"Santiago de Pillaro",
     "wof:parent_id":85670959,
     "wof:placetype":"county",

--- a/data/110/857/255/7/1108572557.geojson
+++ b/data/110/857/255/7/1108572557.geojson
@@ -119,7 +119,7 @@
         }
     ],
     "wof:id":1108572557,
-    "wof:lastmodified":1694492371,
+    "wof:lastmodified":1695886624,
     "wof:name":"Santiago de Pillaro",
     "wof:parent_id":85670959,
     "wof:placetype":"county",

--- a/data/110/857/258/5/1108572585.geojson
+++ b/data/110/857/258/5/1108572585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149298,
-    "geom:area_square_m":1843920117.037308,
+    "geom:area_square_m":1843920078.906338,
     "geom:bbox":"-78.610728,-3.061898,-77.839155,-2.508389",
     "geom:latitude":-2.77943,
     "geom:longitude":-78.30594,
@@ -547,9 +547,10 @@
     "wof:concordances":{
         "hasc:id":"EC.MS.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064563,
-    "wof:geomhash":"5a512609a7d9513eee56f8a65b681ba1",
+    "wof:geomhash":"1172b4283f98bacfe138af44c81807ea",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -559,7 +560,7 @@
         }
     ],
     "wof:id":1108572585,
-    "wof:lastmodified":1636502134,
+    "wof:lastmodified":1695886044,
     "wof:name":"Santiago",
     "wof:parent_id":85670935,
     "wof:placetype":"county",

--- a/data/110/857/269/7/1108572697.geojson
+++ b/data/110/857/269/7/1108572697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026102,
-    "geom:area_square_m":322404789.777058,
+    "geom:area_square_m":322404789.77704,
     "geom:bbox":"-78.6592430763,-2.85451171697,-78.4203053356,-2.54981531159",
     "geom:latitude":-2.675892,
     "geom:longitude":-78.560671,
@@ -98,9 +98,10 @@
         "hasc:id":"EC.AZ.SO",
         "wd:id":"Q1014499"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064567,
-    "wof:geomhash":"83c5553598c6daa1eb46672a137e506a",
+    "wof:geomhash":"e4b129650e32b3e6f9e871d16bfa41fa",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108572697,
-    "wof:lastmodified":1566584308,
+    "wof:lastmodified":1695886622,
     "wof:name":"Sevilla de Oro",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/110/857/273/9/1108572739.geojson
+++ b/data/110/857/273/9/1108572739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.204947,
-    "geom:area_square_m":2534162189.753261,
+    "geom:area_square_m":2534161417.51941,
     "geom:bbox":"-76.90339,-0.567774,-75.897306,-0.000787",
     "geom:latitude":-0.312624,
     "geom:longitude":-76.414226,
@@ -110,9 +110,10 @@
         "hasc:id":"EC.SU.SH",
         "wd:id":"Q1992924"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064569,
-    "wof:geomhash":"3de26196d0ac0be4baecf58b54a044f3",
+    "wof:geomhash":"2ae29811737734698f24ab412bfedd0f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108572739,
-    "wof:lastmodified":1690875587,
+    "wof:lastmodified":1695886621,
     "wof:name":"Shushufindi",
     "wof:parent_id":85670977,
     "wof:placetype":"county",

--- a/data/110/857/278/9/1108572789.geojson
+++ b/data/110/857/278/9/1108572789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053696,
-    "geom:area_square_m":662973134.302347,
+    "geom:area_square_m":662973396.529985,
     "geom:bbox":"-79.025043,-3.28557,-78.668403,-2.975588",
     "geom:latitude":-3.12785,
     "geom:longitude":-78.854731,
@@ -108,9 +108,10 @@
         "hasc:id":"EC.AZ.SG",
         "wd:id":"Q2466113"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064571,
-    "wof:geomhash":"26e4b1d039ab0b25e470cc991e44a8b2",
+    "wof:geomhash":"6b999fb9d91ce9d72d859e630e2d1fb4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108572789,
-    "wof:lastmodified":1690875592,
+    "wof:lastmodified":1695886623,
     "wof:name":"Sigsig",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/110/857/281/9/1108572819.geojson
+++ b/data/110/857/281/9/1108572819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022631,
-    "geom:area_square_m":279664804.474853,
+    "geom:area_square_m":279664763.911566,
     "geom:bbox":"-79.521032,-2.14384,-79.264307,-1.934165",
     "geom:latitude":-2.03555,
     "geom:longitude":-79.4054,
@@ -52,9 +52,10 @@
     "wof:concordances":{
         "hasc:id":"EC.GU.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064573,
-    "wof:geomhash":"c3cd7bd7e56bc785cc1c4e3cd54222c4",
+    "wof:geomhash":"5446877609a2437a1351b21c9b04ee55",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -64,7 +65,7 @@
         }
     ],
     "wof:id":1108572819,
-    "wof:lastmodified":1627522038,
+    "wof:lastmodified":1695886549,
     "wof:name":"Simon Bolivar",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/857/285/1/1108572851.geojson
+++ b/data/110/857/285/1/1108572851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034469,
-    "geom:area_square_m":425028307.055178,
+    "geom:area_square_m":425028345.88089,
     "geom:bbox":"-79.878935,-4.483238,-79.676577,-4.112455",
     "geom:latitude":-4.279787,
     "geom:longitude":-79.779007,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.LJ.SO",
         "wd:id":"Q1990061"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064574,
-    "wof:geomhash":"86ac6fa38c42339e11fd0092d006e9dc",
+    "wof:geomhash":"91616d7f97ecb4499506c77a85b81efa",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108572851,
-    "wof:lastmodified":1690875593,
+    "wof:lastmodified":1695886623,
     "wof:name":"Sozoranga",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/110/857/286/5/1108572865.geojson
+++ b/data/110/857/286/5/1108572865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.161835,
-    "geom:area_square_m":2001047974.03428,
+    "geom:area_square_m":2001048645.598052,
     "geom:bbox":"-80.520926,-0.870723,-80.081051,-0.060912",
     "geom:latitude":-0.439826,
     "geom:longitude":-80.314393,
@@ -119,9 +119,10 @@
         "hasc:id":"EC.MN.SU",
         "wd:id":"Q1992579"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064575,
-    "wof:geomhash":"4cbea6a7422ce25781a1c054d41aa448",
+    "wof:geomhash":"9bb3f06f3ea510002b36dee5bf03cecc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108572865,
-    "wof:lastmodified":1690875587,
+    "wof:lastmodified":1695886043,
     "wof:name":"Sucre",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/110/857/290/7/1108572907.geojson
+++ b/data/110/857/290/7/1108572907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121423,
-    "geom:area_square_m":1501378762.104755,
+    "geom:area_square_m":1501379166.808951,
     "geom:bbox":"-77.807948,0.132456,-77.346199,0.662214",
     "geom:latitude":0.39002,
     "geom:longitude":-77.598598,
@@ -122,9 +122,10 @@
         "hasc:id":"EC.SU.SU",
         "wd:id":"Q1992501"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064577,
-    "wof:geomhash":"01a40aa8f48210e76f59eee9cac1ec48",
+    "wof:geomhash":"b56113c6d35a613574339a26b499d54b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108572907,
-    "wof:lastmodified":1690875595,
+    "wof:lastmodified":1695886624,
     "wof:name":"Sucumb\u00edos",
     "wof:parent_id":85670977,
     "wof:placetype":"county",

--- a/data/110/857/298/5/1108572985.geojson
+++ b/data/110/857/298/5/1108572985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.356741,
-    "geom:area_square_m":4410493283.311899,
+    "geom:area_square_m":4410493811.336312,
     "geom:bbox":"-78.42271,-1.243855,-77.031939,-0.689086",
     "geom:latitude":-0.999455,
     "geom:longitude":-77.805212,
@@ -128,9 +128,10 @@
         "hasc:id":"EC.NA.TE",
         "wd:id":"Q2448860"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064579,
-    "wof:geomhash":"8106182da2ca85aed89abcc1d14fa42f",
+    "wof:geomhash":"ce00c86c6ca8dbe59cfeaf0e3985578a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108572985,
-    "wof:lastmodified":1690875594,
+    "wof:lastmodified":1695886045,
     "wof:name":"Tena",
     "wof:parent_id":85670953,
     "wof:placetype":"county",

--- a/data/110/857/302/1/1108573021.geojson
+++ b/data/110/857/302/1/1108573021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004466,
-    "geom:area_square_m":55202811.553816,
+    "geom:area_square_m":55202873.001115,
     "geom:bbox":"-78.719848,-1.403353,-78.628403,-1.317271",
     "geom:latitude":-1.364203,
     "geom:longitude":-78.670765,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.TU.TI",
         "wd:id":"Q3656352"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064581,
-    "wof:geomhash":"a194cc445df84607cbd4ed98b2cb603c",
+    "wof:geomhash":"38ac086c9b9a473661e35660fc9b529b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108573021,
-    "wof:lastmodified":1690875592,
+    "wof:lastmodified":1695886623,
     "wof:name":"Tisaleo",
     "wof:parent_id":85670959,
     "wof:placetype":"county",

--- a/data/110/857/306/1/1108573061.geojson
+++ b/data/110/857/306/1/1108573061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030055,
-    "geom:area_square_m":371598770.309881,
+    "geom:area_square_m":371598656.057992,
     "geom:bbox":"-80.382613,-0.889253,-80.155949,-0.64265",
     "geom:latitude":-0.775265,
     "geom:longitude":-80.270742,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.MN.TO",
         "wd:id":"Q1992593"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064583,
-    "wof:geomhash":"445d52d2ef480942abd8991c17af4c8c",
+    "wof:geomhash":"97b12e3237088bba1b3b19b8a162df1a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108573061,
-    "wof:lastmodified":1690875586,
+    "wof:lastmodified":1695886621,
     "wof:name":"Tosagua",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/110/857/313/9/1108573139.geojson
+++ b/data/110/857/313/9/1108573139.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"EC.GY.ST",
         "wd:id":"Q1990368"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064585,
     "wof:geomhash":"826ce2cb556997e77df97092fc478375",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108573139,
-    "wof:lastmodified":1695886623,
+    "wof:lastmodified":1696023152,
     "wof:name":"Urbina Jado",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/857/313/9/1108573139.geojson
+++ b/data/110/857/313/9/1108573139.geojson
@@ -125,7 +125,7 @@
         }
     ],
     "wof:id":1108573139,
-    "wof:lastmodified":1694492370,
+    "wof:lastmodified":1695886623,
     "wof:name":"Urbina Jado",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/110/857/317/9/1108573179.geojson
+++ b/data/110/857/317/9/1108573179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030532,
-    "geom:area_square_m":377389311.121,
+    "geom:area_square_m":377389258.288944,
     "geom:bbox":"-79.501932,-1.672674,-79.243356,-1.455499",
     "geom:latitude":-1.563529,
     "geom:longitude":-79.386216,
@@ -107,9 +107,10 @@
         "hasc:id":"EC.LR.UR",
         "wd:id":"Q781359"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064587,
-    "wof:geomhash":"09dbda5cfeb02ec8416143f3057a9d23",
+    "wof:geomhash":"4153b9eaeebe2561583ce29047ea805e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108573179,
-    "wof:lastmodified":1690875596,
+    "wof:lastmodified":1695886624,
     "wof:name":"Urdaneta",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/110/857/323/7/1108573237.geojson
+++ b/data/110/857/323/7/1108573237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067964,
-    "geom:area_square_m":840170513.444094,
+    "geom:area_square_m":840170426.03099,
     "geom:bbox":"-79.540181,-1.537394,-79.266257,-0.95529",
     "geom:latitude":-1.286934,
     "geom:longitude":-79.390052,
@@ -110,9 +110,10 @@
         "hasc:id":"EC.LR.VE",
         "wd:id":"Q3656370"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064589,
-    "wof:geomhash":"62963484e331968d8ce1341888473a3e",
+    "wof:geomhash":"b5aa671752a744147ba7cb1d41c38a9e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108573237,
-    "wof:lastmodified":1690875590,
+    "wof:lastmodified":1695886622,
     "wof:name":"Ventanas",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/110/857/329/3/1108573293.geojson
+++ b/data/110/857/329/3/1108573293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101764,
-    "geom:area_square_m":1255840539.595503,
+    "geom:area_square_m":1255840749.660481,
     "geom:bbox":"-79.157606,-3.819634,-78.814977,-3.331658",
     "geom:latitude":-3.605336,
     "geom:longitude":-78.96514,
@@ -110,9 +110,10 @@
         "hasc:id":"EC.ZC.YC",
         "wd:id":"Q1989457"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064591,
-    "wof:geomhash":"485fd46522c0643ae17fbc2c12598b70",
+    "wof:geomhash":"f91a8c26378b73f169443b6898777e78",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108573293,
-    "wof:lastmodified":1690875595,
+    "wof:lastmodified":1695886624,
     "wof:name":"Yacuambi",
     "wof:parent_id":85670895,
     "wof:placetype":"county",

--- a/data/110/857/333/1/1108573331.geojson
+++ b/data/110/857/333/1/1108573331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083677,
-    "geom:area_square_m":1032467583.081362,
+    "geom:area_square_m":1032468034.187615,
     "geom:bbox":"-78.850123,-3.867773,-78.401983,-3.537421",
     "geom:latitude":-3.744167,
     "geom:longitude":-78.661948,
@@ -101,9 +101,10 @@
         "hasc:id":"EC.ZC.YN",
         "wd:id":"Q4614380"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064593,
-    "wof:geomhash":"8e61c725ab074db437a5e12a3c1532fe",
+    "wof:geomhash":"8a86081c64c008c4da95dc4cf380bece",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108573331,
-    "wof:lastmodified":1690875591,
+    "wof:lastmodified":1695886623,
     "wof:name":"Yanzatza",
     "wof:parent_id":85670895,
     "wof:placetype":"county",

--- a/data/110/857/339/7/1108573397.geojson
+++ b/data/110/857/339/7/1108573397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.099077,
-    "geom:area_square_m":1221774677.558142,
+    "geom:area_square_m":1221774792.487308,
     "geom:bbox":"-80.485956,-4.486707,-80.101244,-3.980349",
     "geom:latitude":-4.223093,
     "geom:longitude":-80.323963,
@@ -95,9 +95,10 @@
         "hasc:id":"EC.LJ.ZA",
         "wd:id":"Q948227"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1474064595,
-    "wof:geomhash":"307f442e676b50d5ed281453e47a0664",
+    "wof:geomhash":"6ba1a2aac974b30aea0b7848d5b67410",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108573397,
-    "wof:lastmodified":1690875586,
+    "wof:lastmodified":1695886621,
     "wof:name":"Zapotillo",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/421/166/581/421166581.geojson
+++ b/data/421/166/581/421166581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.279027,
-    "geom:area_square_m":3450214749.181064,
+    "geom:area_square_m":3450215203.792007,
     "geom:bbox":"-76.437505,-0.170715,-75.25476,0.437024",
     "geom:latitude":0.081763,
     "geom:longitude":-76.010517,
@@ -174,12 +174,13 @@
         "qs_pg:id":1242728,
         "wd:id":"Q1992558"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008695,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5fa2c6aaee8399f5d1e7a1c2d48f26e4",
+    "wof:geomhash":"3a2a48d048fbaf0c0acf6f9c89ebe48a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -189,7 +190,7 @@
         }
     ],
     "wof:id":421166581,
-    "wof:lastmodified":1690875608,
+    "wof:lastmodified":1695886046,
     "wof:name":"Putumayo",
     "wof:parent_id":85670977,
     "wof:placetype":"county",

--- a/data/421/168/623/421168623.geojson
+++ b/data/421/168/623/421168623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011268,
-    "geom:area_square_m":139333313.036156,
+    "geom:area_square_m":139333120.651443,
     "geom:bbox":"-78.480005,-0.505145,-78.390972,-0.294686",
     "geom:latitude":-0.399134,
     "geom:longitude":-78.44149,
@@ -140,12 +140,13 @@
         "qs_pg:id":890676,
         "wd:id":"Q1990505"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008771,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"40e807bc4e496786dd4201df2e967768",
+    "wof:geomhash":"45b3d0e2ec8b6f11dabbe4be77c4174d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421168623,
-    "wof:lastmodified":1690875608,
+    "wof:lastmodified":1695886796,
     "wof:name":"Rumi\u00f1ahui",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/169/435/421169435.geojson
+++ b/data/421/169/435/421169435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107131,
-    "geom:area_square_m":1324638312.533543,
+    "geom:area_square_m":1324638552.824132,
     "geom:bbox":"-80.106667,0.25525,-79.736111,0.813167",
     "geom:latitude":0.529879,
     "geom:longitude":-79.937009,
@@ -153,12 +153,13 @@
         "qs_pg:id":1264187,
         "wd:id":"Q3991172"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008810,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3cb263b9ad235e90a8733d548455153b",
+    "wof:geomhash":"3ff09e2a44cb3fa40ff0bb65a2323307",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":421169435,
-    "wof:lastmodified":1690875617,
+    "wof:lastmodified":1695886046,
     "wof:name":"Muisne",
     "wof:parent_id":85670963,
     "wof:placetype":"county",

--- a/data/421/169/627/421169627.geojson
+++ b/data/421/169/627/421169627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006487,
-    "geom:area_square_m":80216293.333376,
+    "geom:area_square_m":80216360.016446,
     "geom:bbox":"-78.245894,0.263258,-78.134081,0.399154",
     "geom:latitude":0.337775,
     "geom:longitude":-78.197465,
@@ -132,12 +132,13 @@
         "qs_pg:id":224360,
         "wd:id":"Q1992605"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008817,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0d0383ae739c2a74ea19a8f48b4883e2",
+    "wof:geomhash":"f1aa9f1db36071a3dd90cd5a69a46659",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421169627,
-    "wof:lastmodified":1690875615,
+    "wof:lastmodified":1695886796,
     "wof:name":"Antonio Ante",
     "wof:parent_id":85670971,
     "wof:placetype":"county",

--- a/data/421/171/743/421171743.geojson
+++ b/data/421/171/743/421171743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.152632,
-    "geom:area_square_m":1886747687.48277,
+    "geom:area_square_m":1886747464.050217,
     "geom:bbox":"-79.289255,-1.722061,-78.838707,-1.146593",
     "geom:latitude":-1.412729,
     "geom:longitude":-79.047943,
@@ -147,12 +147,13 @@
         "qs_pg:id":1264184,
         "wd:id":"Q2466609"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008905,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d1e83d11ad7548c8c0f8010ed5d824de",
+    "wof:geomhash":"927ed01c1b04edf6d8132360bdb03850",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":421171743,
-    "wof:lastmodified":1690875654,
+    "wof:lastmodified":1695886048,
     "wof:name":"Guaranda",
     "wof:parent_id":85670905,
     "wof:placetype":"county",

--- a/data/421/171/745/421171745.geojson
+++ b/data/421/171/745/421171745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09222,
-    "geom:area_square_m":1140268518.7284,
+    "geom:area_square_m":1140268164.751382,
     "geom:bbox":"-78.455571,0.159425,-77.950402,0.877563",
     "geom:latitude":0.505603,
     "geom:longitude":-78.170365,
@@ -165,12 +165,13 @@
         "qs_pg:id":1264185,
         "wd:id":"Q295092"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008905,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a3f54862bf108457f8f045623612deda",
+    "wof:geomhash":"ebcfc3eaccc4743b6bfaafcca33fef80",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":421171745,
-    "wof:lastmodified":1690875655,
+    "wof:lastmodified":1695886799,
     "wof:name":"Ibarra",
     "wof:parent_id":85670971,
     "wof:placetype":"county",

--- a/data/421/171/747/421171747.geojson
+++ b/data/421/171/747/421171747.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.177375,
-    "geom:area_square_m":2193275774.58666,
+    "geom:area_square_m":2193275609.247494,
     "geom:bbox":"-77.969155,-0.150262,-77.244947,0.342703",
     "geom:latitude":0.079067,
     "geom:longitude":-77.5805,
@@ -180,12 +180,13 @@
         "qs_pg:id":1264186,
         "wd:id":"Q1990055"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008905,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4c0f74a50db30786c9d6911da31be420",
+    "wof:geomhash":"dcff7e97dfe10f637c25dd60b7f4fd03",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":421171747,
-    "wof:lastmodified":1690875654,
+    "wof:lastmodified":1695886799,
     "wof:name":"Gonzalo Pizarro",
     "wof:parent_id":85670977,
     "wof:placetype":"county",

--- a/data/421/171/751/421171751.geojson
+++ b/data/421/171/751/421171751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040446,
-    "geom:area_square_m":500119957.109733,
+    "geom:area_square_m":500119708.84939,
     "geom:bbox":"-78.602712,0.123108,-78.127642,0.3243",
     "geom:latitude":0.227862,
     "geom:longitude":-78.319007,
@@ -137,12 +137,13 @@
         "qs_pg:id":1264188,
         "wd:id":"Q3656211"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008905,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c681d758a3e5780e7fba707adde721e7",
+    "wof:geomhash":"5db69bc7327981694f0610d95f6ff24d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421171751,
-    "wof:lastmodified":1690875654,
+    "wof:lastmodified":1695886799,
     "wof:name":"Otavalo",
     "wof:parent_id":85670971,
     "wof:placetype":"county",

--- a/data/421/171/753/421171753.geojson
+++ b/data/421/171/753/421171753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026593,
-    "geom:area_square_m":328825918.780664,
+    "geom:area_square_m":328825880.713337,
     "geom:bbox":"-78.406956,-0.035638,-78.156696,0.151527",
     "geom:latitude":0.05367,
     "geom:longitude":-78.274507,
@@ -135,12 +135,13 @@
         "qs_pg:id":1264192,
         "wd:id":"Q4504255"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008905,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7a56477ef2d8ac6adbad61c35c6bc996",
+    "wof:geomhash":"fdb38b1e8a99c4d31c2c7d3d0f2844f1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421171753,
-    "wof:lastmodified":1690875653,
+    "wof:lastmodified":1695886799,
     "wof:name":"Pedro Moncayo",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/171/755/421171755.geojson
+++ b/data/421/171/755/421171755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.160935,
-    "geom:area_square_m":1988011174.000747,
+    "geom:area_square_m":1988010811.526457,
     "geom:bbox":"-79.832108,-2.859307,-79.36559,-2.289306",
     "geom:latitude":-2.556032,
     "geom:longitude":-79.615589,
@@ -107,12 +107,13 @@
         "hasc:id":"EC.GY.NL",
         "qs_pg:id":1264193
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008905,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e054e4e824e590e69005880cb073580c",
+    "wof:geomhash":"c10aecd87d7b2c2f632fb80f8cacf84e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":421171755,
-    "wof:lastmodified":1627522037,
+    "wof:lastmodified":1695886547,
     "wof:name":"Naranjal",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/171/759/421171759.geojson
+++ b/data/421/171/759/421171759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039777,
-    "geom:area_square_m":491766899.032957,
+    "geom:area_square_m":491767265.42878,
     "geom:bbox":"-78.839872,-1.152661,-78.393621,-0.952888",
     "geom:latitude":-1.057744,
     "geom:longitude":-78.612807,
@@ -159,12 +159,13 @@
         "qs_pg:id":1264195,
         "wd:id":"Q2707803"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008906,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"52273cd1035680df5ac592ade0737daf",
+    "wof:geomhash":"f72362adcf12a6c551288e3731e4d4c2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":421171759,
-    "wof:lastmodified":1690875654,
+    "wof:lastmodified":1695886048,
     "wof:name":"Salcedo",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/421/171/763/421171763.geojson
+++ b/data/421/171/763/421171763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.243373,
-    "geom:area_square_m":3008880463.231814,
+    "geom:area_square_m":3008880502.086461,
     "geom:bbox":"-78.98216,0.502116,-78.425919,1.454337",
     "geom:latitude":0.997285,
     "geom:longitude":-78.676543,
@@ -225,12 +225,13 @@
         "qs_pg:id":1264206,
         "wd:id":"Q431438"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008906,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"35f478958cda64079d9ed9881f2a202e",
+    "wof:geomhash":"75a7bb2ad3a7eee0c7a4b8cbc140cb8c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -240,7 +241,7 @@
         }
     ],
     "wof:id":421171763,
-    "wof:lastmodified":1690875653,
+    "wof:lastmodified":1695886048,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85670963,
     "wof:placetype":"county",

--- a/data/421/172/549/421172549.geojson
+++ b/data/421/172/549/421172549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028383,
-    "geom:area_square_m":350918992.704234,
+    "geom:area_square_m":350918673.61796,
     "geom:bbox":"-80.589009,-0.970595,-80.264933,-0.795707",
     "geom:latitude":-0.899325,
     "geom:longitude":-80.428862,
@@ -132,12 +132,13 @@
         "qs_pg:id":1313107,
         "wd:id":"Q1990564"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008946,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"705ce74822e4ae0e0d4ab45cf6bf7b85",
+    "wof:geomhash":"f5b8405f2756aebd17e2e644ecda27e9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421172549,
-    "wof:lastmodified":1690875629,
+    "wof:lastmodified":1695886797,
     "wof:name":"Rocafuerte",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/173/271/421173271.geojson
+++ b/data/421/173/271/421173271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05869,
-    "geom:area_square_m":725459921.225329,
+    "geom:area_square_m":725459562.442101,
     "geom:bbox":"-79.872545,-1.741076,-79.517318,-1.311548",
     "geom:latitude":-1.520799,
     "geom:longitude":-79.730827,
@@ -129,12 +129,13 @@
         "qs_pg:id":286231,
         "wd:id":"Q1707682"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459008976,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"743efbdf28a1a20959c4cfe7fddbf9eb",
+    "wof:geomhash":"61f4d5b58fe06b5a779467f66ecc8cd0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421173271,
-    "wof:lastmodified":1690875625,
+    "wof:lastmodified":1695886796,
     "wof:name":"Vinces",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/421/175/411/421175411.geojson
+++ b/data/421/175/411/421175411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02487,
-    "geom:area_square_m":307472482.109752,
+    "geom:area_square_m":307472434.277988,
     "geom:bbox":"-81.082085,-1.287917,-80.648781,-0.922139",
     "geom:latitude":-1.026054,
     "geom:longitude":-80.802397,
@@ -152,12 +152,13 @@
         "qs_pg:id":369017,
         "wd:id":"Q1990138"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4b6d8e48a31fc416a9ef0d0434baf89a",
+    "wof:geomhash":"709f35b833a54d7fe7d51767f3e10254",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421175411,
-    "wof:lastmodified":1690875634,
+    "wof:lastmodified":1695886047,
     "wof:name":"Manta",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/175/413/421175413.geojson
+++ b/data/421/175/413/421175413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120366,
-    "geom:area_square_m":1488298233.162052,
+    "geom:area_square_m":1488298840.750005,
     "geom:bbox":"-78.951864,-0.719393,-78.315386,-0.270321",
     "geom:latitude":-0.488552,
     "geom:longitude":-78.627875,
@@ -138,12 +138,13 @@
         "qs_pg:id":369018,
         "wd:id":"Q1990543"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"29f2e77796554f43e1b5fcf4abc40e34",
+    "wof:geomhash":"3bbd1bb0f4da3da990797d14c7f611f1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":421175413,
-    "wof:lastmodified":1690875632,
+    "wof:lastmodified":1695886797,
     "wof:name":"Mej\u00eda",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/175/415/421175415.geojson
+++ b/data/421/175/415/421175415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043519,
-    "geom:area_square_m":537955789.625889,
+    "geom:area_square_m":537955935.137459,
     "geom:bbox":"-78.16985,-1.674809,-77.914227,-1.213859",
     "geom:latitude":-1.414932,
     "geom:longitude":-78.044737,
@@ -183,12 +183,13 @@
         "qs_pg:id":369019,
         "wd:id":"Q1992979"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d334043031c94eedc7c4e61890c16600",
+    "wof:geomhash":"03297780104960263244809a9839e520",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -198,7 +199,7 @@
         }
     ],
     "wof:id":421175415,
-    "wof:lastmodified":1690875633,
+    "wof:lastmodified":1695886797,
     "wof:name":"Mera",
     "wof:parent_id":85670949,
     "wof:placetype":"county",

--- a/data/421/175/419/421175419.geojson
+++ b/data/421/175/419/421175419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043228,
-    "geom:area_square_m":534369751.51799,
+    "geom:area_square_m":534369751.51796,
     "geom:bbox":"-80.4973088983,-1.55264865762,-80.2516471808,-1.20670612644",
     "geom:latitude":-1.382244,
     "geom:longitude":-80.373596,
@@ -120,12 +120,13 @@
         "qs_pg:id":369060,
         "wd:id":"Q1992944"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e130a41c8d80784d677d74075a0c481f",
+    "wof:geomhash":"384464ca58a0c1764d04c0aa3d37b940",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421175419,
-    "wof:lastmodified":1582351941,
+    "wof:lastmodified":1695886797,
     "wof:name":"Veinticuatro de Mayo",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/175/423/421175423.geojson
+++ b/data/421/175/423/421175423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.34232,
-    "geom:area_square_m":4228815651.69999,
+    "geom:area_square_m":4228815651.700014,
     "geom:bbox":"-80.461609,-3.062599,-79.71096,-1.961942",
     "geom:latitude":-2.487508,
     "geom:longitude":-80.086806,
@@ -151,13 +151,14 @@
         "qs_pg:id":369061,
         "wd:id":"Q1991935"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009067,
     "wof:geom_alt":[
         "quattroshapes",
         "meso"
     ],
-    "wof:geomhash":"c12d575a9942b275f83e8d751627b24f",
+    "wof:geomhash":"8c0f2758448a52f6e79119e735359d5f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421175423,
-    "wof:lastmodified":1690875633,
+    "wof:lastmodified":1695886577,
     "wof:name":"Guayaquil",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/176/841/421176841.geojson
+++ b/data/421/176/841/421176841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034034,
-    "geom:area_square_m":420684632.182058,
+    "geom:area_square_m":420684373.190956,
     "geom:bbox":"-80.851303,-1.687829,-80.665774,-1.373538",
     "geom:latitude":-1.559109,
     "geom:longitude":-80.748637,
@@ -129,12 +129,13 @@
         "qs_pg:id":1087918,
         "wd:id":"Q1992965"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009121,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b54a4ee53a267f819cec98b2987f24d3",
+    "wof:geomhash":"584292061d1d05a501b689cd1ce29dd5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421176841,
-    "wof:lastmodified":1690875652,
+    "wof:lastmodified":1695886799,
     "wof:name":"Puerto L\u00f3pez",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/177/637/421177637.geojson
+++ b/data/421/177/637/421177637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.250331,
-    "geom:area_square_m":3095375005.958664,
+    "geom:area_square_m":3095375492.378415,
     "geom:bbox":"-77.216042,-0.129486,-76.238041,0.389616",
     "geom:latitude":0.111778,
     "geom:longitude":-76.770427,
@@ -143,12 +143,13 @@
         "qs_pg:id":430317,
         "wd:id":"Q2466453"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009156,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"948a563cc83f6bf313fed06450056bda",
+    "wof:geomhash":"d81afca366b321a00765bf6b21ba5437",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":421177637,
-    "wof:lastmodified":1690875646,
+    "wof:lastmodified":1695886798,
     "wof:name":"Lago Agrio",
     "wof:parent_id":85670977,
     "wof:placetype":"county",

--- a/data/421/178/137/421178137.geojson
+++ b/data/421/178/137/421178137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098488,
-    "geom:area_square_m":1217802720.22455,
+    "geom:area_square_m":1217802798.538619,
     "geom:bbox":"-77.156828,-0.464935,-76.601755,-0.053715",
     "geom:latitude":-0.277713,
     "geom:longitude":-76.889712,
@@ -96,12 +96,13 @@
         "qs_pg:id":44036,
         "wd:id":"Q1992899"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009172,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c6f951281fa8b5b98e09d64aa5ce7835",
+    "wof:geomhash":"52236fbb28a67fc77ba9d9d6cccd0537",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":421178137,
-    "wof:lastmodified":1627522037,
+    "wof:lastmodified":1695886547,
     "wof:name":"Joya de los Sachas",
     "wof:parent_id":85670941,
     "wof:placetype":"county",

--- a/data/421/178/141/421178141.geojson
+++ b/data/421/178/141/421178141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053947,
-    "geom:area_square_m":666994062.45394,
+    "geom:area_square_m":666993695.461805,
     "geom:bbox":"-79.317106,-1.001112,-78.985247,-0.562625",
     "geom:latitude":-0.799262,
     "geom:longitude":-79.137756,
@@ -133,12 +133,13 @@
         "qs_pg:id":44044,
         "wd:id":"Q950390"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009172,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4b68b814315fb74a538a11a5c96fd6cd",
+    "wof:geomhash":"466310d5289cc486c6e00765b68e9ad0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421178141,
-    "wof:lastmodified":1690875650,
+    "wof:lastmodified":1695886799,
     "wof:name":"La Man\u00e1",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/421/179/215/421179215.geojson
+++ b/data/421/179/215/421179215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021724,
-    "geom:area_square_m":268393681.86686,
+    "geom:area_square_m":268393698.707094,
     "geom:bbox":"-79.041864,-2.407842,-78.803352,-2.234513",
     "geom:latitude":-2.330366,
     "geom:longitude":-78.905118,
@@ -132,12 +132,13 @@
         "qs_pg:id":369001,
         "wd:id":"Q2448829"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009208,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fee7eec8113ca4f085cbb0d4bd8825c7",
+    "wof:geomhash":"aedd34e4ffc2bebe271a182968b5f296",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421179215,
-    "wof:lastmodified":1690875649,
+    "wof:lastmodified":1695886798,
     "wof:name":"Chunchi",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/180/535/421180535.geojson
+++ b/data/421/180/535/421180535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04501,
-    "geom:area_square_m":556517977.588837,
+    "geom:area_square_m":556517448.989474,
     "geom:bbox":"-78.218325,0.557828,-77.871574,0.860938",
     "geom:latitude":0.712134,
     "geom:longitude":-78.037929,
@@ -138,12 +138,13 @@
         "qs_pg:id":286230,
         "wd:id":"Q733734"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009262,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6c6940c57be23c954211324251722091",
+    "wof:geomhash":"74bb146fad859e85434f04081dcc33b4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":421180535,
-    "wof:lastmodified":1690875622,
+    "wof:lastmodified":1695886796,
     "wof:name":"Espejo",
     "wof:parent_id":85670967,
     "wof:placetype":"county",

--- a/data/421/181/765/421181765.geojson
+++ b/data/421/181/765/421181765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052488,
-    "geom:area_square_m":648942034.712794,
+    "geom:area_square_m":648942250.325467,
     "geom:bbox":"-89.980164,-1.407111,-89.240471,0.348417",
     "geom:latitude":-0.848314,
     "geom:longitude":-89.468327,
@@ -150,12 +150,13 @@
         "qs_pg:id":501895,
         "wd:id":"Q14920555"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009306,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"31dda774d37166e7c46a5de98165aba0",
+    "wof:geomhash":"58465353c1807926c819d438ea9952d9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":421181765,
-    "wof:lastmodified":1690875631,
+    "wof:lastmodified":1695886797,
     "wof:name":"San Crist\u00f3bal",
     "wof:parent_id":85670899,
     "wof:placetype":"county",

--- a/data/421/182/157/421182157.geojson
+++ b/data/421/182/157/421182157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112447,
-    "geom:area_square_m":1390294183.297918,
+    "geom:area_square_m":1390293546.191345,
     "geom:bbox":"-78.832844,-1.011604,-78.384366,-0.589689",
     "geom:latitude":-0.788904,
     "geom:longitude":-78.578637,
@@ -138,12 +138,13 @@
         "qs_pg:id":891811,
         "wd:id":"Q2182152"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009320,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3147b4feed51add90782c2e8ac9bdb68",
+    "wof:geomhash":"2c6d27edcc9700d0d106f45afe345ace",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":421182157,
-    "wof:lastmodified":1690875650,
+    "wof:lastmodified":1695886047,
     "wof:name":"Latacunga",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/421/182/159/421182159.geojson
+++ b/data/421/182/159/421182159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153086,
-    "geom:area_square_m":1888173907.949126,
+    "geom:area_square_m":1888174395.635073,
     "geom:bbox":"-79.541484,-4.506712,-79.096636,-3.666113",
     "geom:latitude":-4.060607,
     "geom:longitude":-79.249608,
@@ -180,12 +180,13 @@
         "qs_pg:id":891812,
         "wd:id":"Q1158141"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009320,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5f691efd84c6ec8a1016d8f2542acb6e",
+    "wof:geomhash":"aee4a13f6ff54ef0134523df38165389",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":421182159,
-    "wof:lastmodified":1690875650,
+    "wof:lastmodified":1695886047,
     "wof:name":"Loja",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/421/182/449/421182449.geojson
+++ b/data/421/182/449/421182449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1932,
-    "geom:area_square_m":2383166033.803331,
+    "geom:area_square_m":2383165505.273994,
     "geom:bbox":"-79.198159,-4.262137,-78.475203,-3.700314",
     "geom:latitude":-3.986457,
     "geom:longitude":-78.912821,
@@ -167,12 +167,13 @@
         "qs_pg:id":911539,
         "wd:id":"Q1989431"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009330,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dedadcc3528e8212d4aa80d1c2d88d08",
+    "wof:geomhash":"e464c7698bb51db7e6801577c1e9501b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":421182449,
-    "wof:lastmodified":1690875651,
+    "wof:lastmodified":1695886048,
     "wof:name":"Zamora",
     "wof:parent_id":85670895,
     "wof:placetype":"county",

--- a/data/421/183/023/421183023.geojson
+++ b/data/421/183/023/421183023.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019168,
-    "geom:area_square_m":236755185.334886,
+    "geom:area_square_m":236755244.172034,
     "geom:bbox":"-79.093768,-2.73967,-78.860697,-2.601024",
     "geom:latitude":-2.669351,
     "geom:longitude":-78.959957,
@@ -134,12 +134,13 @@
         "qs_pg:id":959197,
         "wd:id":"Q1529187"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009355,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6b944391d31851baaedb25bf4cf90f2c",
+    "wof:geomhash":"dd98f4c0d40e3a05dde10ec75683dc55",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421183023,
-    "wof:lastmodified":1690875647,
+    "wof:lastmodified":1695886798,
     "wof:name":"Bibli\u00e1n",
     "wof:parent_id":85670909,
     "wof:placetype":"county",

--- a/data/421/183/147/421183147.geojson
+++ b/data/421/183/147/421183147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.902052,
-    "geom:area_square_m":11152438393.195801,
+    "geom:area_square_m":11152437835.41906,
     "geom:bbox":"-76.594658,-1.563567,-75.188794,-0.402269",
     "geom:latitude":-0.94484,
     "geom:longitude":-75.88323,
@@ -140,12 +140,13 @@
         "qs_pg:id":963705,
         "wd:id":"Q2466482"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009359,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"85ce3bb62be99a32b5b91d0042ba3a2f",
+    "wof:geomhash":"be866f28ec84719501a914e06120d359",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421183147,
-    "wof:lastmodified":1690875648,
+    "wof:lastmodified":1695886799,
     "wof:name":"Aguarico",
     "wof:parent_id":85670941,
     "wof:placetype":"county",

--- a/data/421/183/483/421183483.geojson
+++ b/data/421/183/483/421183483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164269,
-    "geom:area_square_m":2031099209.280329,
+    "geom:area_square_m":2031099016.165468,
     "geom:bbox":"-90.873726,-1.357917,-90.028748,0.643528",
     "geom:latitude":-0.48126,
     "geom:longitude":-90.48644,
@@ -293,12 +293,13 @@
         "qs_pg:id":978984,
         "wd:id":"Q3632781"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009371,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"82fc652abe39c13518c5d37b909f9adb",
+    "wof:geomhash":"e2ff71e207cf5c52b0d88695cf6bdc9d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -308,7 +309,7 @@
         }
     ],
     "wof:id":421183483,
-    "wof:lastmodified":1690875647,
+    "wof:lastmodified":1695886047,
     "wof:name":"Santa Cruz",
     "wof:parent_id":85670899,
     "wof:placetype":"county",

--- a/data/421/183/941/421183941.geojson
+++ b/data/421/183/941/421183941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.261316,
-    "geom:area_square_m":3220513459.666162,
+    "geom:area_square_m":3220513608.863409,
     "geom:bbox":"-79.429451,-5.013975,-78.863844,-4.226745",
     "geom:latitude":-4.664015,
     "geom:longitude":-79.116851,
@@ -137,12 +137,13 @@
         "qs_pg:id":986273,
         "wd:id":"Q1989134"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009395,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8337d5e502d45b55ce9cb251f21cb647",
+    "wof:geomhash":"95c70d831a9505a2385818482ab8c6bc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421183941,
-    "wof:lastmodified":1690875647,
+    "wof:lastmodified":1695886799,
     "wof:name":"Chinchipe",
     "wof:parent_id":85670895,
     "wof:placetype":"county",

--- a/data/421/184/203/421184203.geojson
+++ b/data/421/184/203/421184203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086014,
-    "geom:area_square_m":1063127262.750815,
+    "geom:area_square_m":1063127201.603811,
     "geom:bbox":"-80.573228,-1.943955,-80.180321,-1.452631",
     "geom:latitude":-1.658107,
     "geom:longitude":-80.395889,
@@ -111,12 +111,13 @@
         "qs_pg:id":990188,
         "wd:id":"Q7125333"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009403,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d6724849b43d3ace067a5033a05a2a51",
+    "wof:geomhash":"2b92209b9e10aea854dfe14d94da39a0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421184203,
-    "wof:lastmodified":1690875643,
+    "wof:lastmodified":1695886798,
     "wof:name":"Paj\u00e1n",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/184/411/421184411.geojson
+++ b/data/421/184/411/421184411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030099,
-    "geom:area_square_m":372040725.945197,
+    "geom:area_square_m":372040918.230772,
     "geom:bbox":"-78.544023,-1.674142,-78.357451,-1.429984",
     "geom:latitude":-1.561902,
     "geom:longitude":-78.449416,
@@ -125,12 +125,13 @@
         "qs_pg:id":995778,
         "wd:id":"Q2448780"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009409,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"02e37aae7b7802539d092b5e6b871a24",
+    "wof:geomhash":"324e2f5070c808bfadac384ea755de64",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421184411,
-    "wof:lastmodified":1690875644,
+    "wof:lastmodified":1695886798,
     "wof:name":"Penipe",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/184/413/421184413.geojson
+++ b/data/421/184/413/421184413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062572,
-    "geom:area_square_m":773671229.225917,
+    "geom:area_square_m":773671229.225855,
     "geom:bbox":"-78.5276014845,0.371699930054,-78.1168053796,0.785792879277",
     "geom:latitude":0.567575,
     "geom:longitude":-78.314563,
@@ -114,12 +114,13 @@
         "qs_pg:id":995779,
         "wd:id":"Q1990515"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009410,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3654df37fc3c8de151894e46019d390a",
+    "wof:geomhash":"7c35ff086e5ee54843f282032c4e5fed",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421184413,
-    "wof:lastmodified":1582351942,
+    "wof:lastmodified":1695886798,
     "wof:name":"San Miguel de Urcuqu\u00ed",
     "wof:parent_id":85670971,
     "wof:placetype":"county",

--- a/data/421/184/627/421184627.geojson
+++ b/data/421/184/627/421184627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088315,
-    "geom:area_square_m":1089947659.164012,
+    "geom:area_square_m":1089947725.030237,
     "geom:bbox":"-79.497513,-3.722616,-79.098081,-3.32675",
     "geom:latitude":-3.535994,
     "geom:longitude":-79.305867,
@@ -132,12 +132,13 @@
         "qs_pg:id":1002632,
         "wd:id":"Q1990045"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009417,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0eaf2115005e0ecca0b4088b0b617315",
+    "wof:geomhash":"3b0ab72212e93058200f9df54ba39afb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421184627,
-    "wof:lastmodified":1690875643,
+    "wof:lastmodified":1695886798,
     "wof:name":"Saraguro",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/421/184/733/421184733.geojson
+++ b/data/421/184/733/421184733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05365,
-    "geom:area_square_m":662120581.414905,
+    "geom:area_square_m":662120578.02519,
     "geom:bbox":"-79.651297,-3.708648,-79.36281,-3.305845",
     "geom:latitude":-3.54151,
     "geom:longitude":-79.518412,
@@ -135,12 +135,13 @@
         "qs_pg:id":1005282,
         "wd:id":"Q2448769"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009420,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"81af86ac2c25e736431ec8be28755e38",
+    "wof:geomhash":"fa24bae1c220a7884d15bdd01a36f9b8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421184733,
-    "wof:lastmodified":1690875643,
+    "wof:lastmodified":1695886798,
     "wof:name":"Zaruma",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/421/184/851/421184851.geojson
+++ b/data/421/184/851/421184851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175947,
-    "geom:area_square_m":2175471993.802384,
+    "geom:area_square_m":2175471610.9619,
     "geom:bbox":"-77.627997,-0.948163,-77.067586,-0.344619",
     "geom:latitude":-0.640614,
     "geom:longitude":-77.34938,
@@ -207,12 +207,13 @@
         "qs_pg:id":1119690,
         "wd:id":"Q3586431"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009424,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d98c69d4450c63fb5409cfa8b2e20c6",
+    "wof:geomhash":"fa124dca96150f864529c9b7fa14916d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -222,7 +223,7 @@
         }
     ],
     "wof:id":421184851,
-    "wof:lastmodified":1690875643,
+    "wof:lastmodified":1695886047,
     "wof:name":"Loreto",
     "wof:parent_id":85670941,
     "wof:placetype":"county",

--- a/data/421/184/855/421184855.geojson
+++ b/data/421/184/855/421184855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01692,
-    "geom:area_square_m":209196178.780426,
+    "geom:area_square_m":209196326.095409,
     "geom:bbox":"-78.815792,-0.923487,-78.641846,-0.746616",
     "geom:latitude":-0.824873,
     "geom:longitude":-78.739631,
@@ -126,12 +126,13 @@
         "qs_pg:id":1119695,
         "wd:id":"Q920244"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009424,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e69b268536189a40fc22f1de36ad03d3",
+    "wof:geomhash":"b1d050eb1371610dcc37a7f82aba57d1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421184855,
-    "wof:lastmodified":1690875645,
+    "wof:lastmodified":1695886798,
     "wof:name":"Saquisil\u00ed",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/421/184/865/421184865.geojson
+++ b/data/421/184/865/421184865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102646,
-    "geom:area_square_m":1269160386.720421,
+    "geom:area_square_m":1269160441.911104,
     "geom:bbox":"-79.108998,-0.891737,-78.725552,-0.331313",
     "geom:latitude":-0.641526,
     "geom:longitude":-78.916668,
@@ -132,12 +132,13 @@
         "qs_pg:id":1119697,
         "wd:id":"Q2639966"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009424,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aed8863d078a95664d9e18cdfc4fa6a2",
+    "wof:geomhash":"d69382d8df5f840395213f11e4b344c6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421184865,
-    "wof:lastmodified":1690875645,
+    "wof:lastmodified":1695886798,
     "wof:name":"Sigchos",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/421/185/337/421185337.geojson
+++ b/data/421/185/337/421185337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081876,
-    "geom:area_square_m":1011954416.390516,
+    "geom:area_square_m":1011954019.58087,
     "geom:bbox":"-78.897528,-1.949254,-78.394893,-1.460494",
     "geom:latitude":-1.71728,
     "geom:longitude":-78.634856,
@@ -144,12 +144,13 @@
         "qs_pg:id":890675,
         "wd:id":"Q2448899"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009439,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2e02eef264e088d6d5494bd4b7ae721a",
+    "wof:geomhash":"2d4744a8d2d5648225929c0454db688c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":421185337,
-    "wof:lastmodified":1690875655,
+    "wof:lastmodified":1695886799,
     "wof:name":"Riobamba",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/185/491/421185491.geojson
+++ b/data/421/185/491/421185491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.554148,
-    "geom:area_square_m":6851668327.032974,
+    "geom:area_square_m":6851667653.33875,
     "geom:bbox":"-77.301363,-1.127384,-75.975681,-0.03698",
     "geom:latitude":-0.639752,
     "geom:longitude":-76.76771,
@@ -216,12 +216,13 @@
         "qs_pg:id":897119,
         "wd:id":"Q1992935"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009444,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e0665e51e74d37166b56fd6fbd36740b",
+    "wof:geomhash":"c7b5d81d91e195d4c457b8b40aad9fe9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":421185491,
-    "wof:lastmodified":1636502165,
+    "wof:lastmodified":1695886048,
     "wof:name":"Orellana",
     "wof:parent_id":85670941,
     "wof:placetype":"county",

--- a/data/421/185/493/421185493.geojson
+++ b/data/421/185/493/421185493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138162,
-    "geom:area_square_m":1708359956.006202,
+    "geom:area_square_m":1708360769.226418,
     "geom:bbox":"-79.017521,0.203434,-78.215826,0.58678",
     "geom:latitude":0.359229,
     "geom:longitude":-78.582166,
@@ -135,12 +135,13 @@
         "qs_pg:id":897120,
         "wd:id":"Q1992864"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009445,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"73bffe48164aac1af2652aa5b9c9fcd4",
+    "wof:geomhash":"92d8e4843dffcb1daa2236214b60f2ed",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421185493,
-    "wof:lastmodified":1690875656,
+    "wof:lastmodified":1695886799,
     "wof:name":"Cotacachi",
     "wof:parent_id":85670971,
     "wof:placetype":"county",

--- a/data/421/185/495/421185495.geojson
+++ b/data/421/185/495/421185495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.250621,
-    "geom:area_square_m":3095087441.403238,
+    "geom:area_square_m":3095088111.990241,
     "geom:bbox":"-79.593589,-3.174068,-78.84655,-2.554299",
     "geom:latitude":-2.869583,
     "geom:longitude":-79.211658,
@@ -233,12 +233,13 @@
         "qs_pg:id":897121,
         "wd:id":"Q629038"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009445,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"26fe601b8c4908e429d636d680f92ef3",
+    "wof:geomhash":"bb8c173c6bf19264c340e7c09018d435",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -248,7 +249,7 @@
         }
     ],
     "wof:id":421185495,
-    "wof:lastmodified":1690875656,
+    "wof:lastmodified":1695886799,
     "wof:name":"Cuenca",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/421/185/497/421185497.geojson
+++ b/data/421/185/497/421185497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10525,
-    "geom:area_square_m":1301240415.542139,
+    "geom:area_square_m":1301240403.356812,
     "geom:bbox":"-79.194482,-1.196234,-78.611119,-0.80975",
     "geom:latitude":-0.989634,
     "geom:longitude":-78.896877,
@@ -132,12 +132,13 @@
         "qs_pg:id":897122,
         "wd:id":"Q385955"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009445,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e7015c4f0f25e63521f75c060b8a9af4",
+    "wof:geomhash":"e7a6d24a72cba02d7c629e15a19ba2d0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421185497,
-    "wof:lastmodified":1690875655,
+    "wof:lastmodified":1695886799,
     "wof:name":"Pujil\u00ed",
     "wof:parent_id":85670915,
     "wof:placetype":"county",

--- a/data/421/185/499/421185499.geojson
+++ b/data/421/185/499/421185499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.345083,
-    "geom:area_square_m":28983792430.706261,
+    "geom:area_square_m":28983792430.705551,
     "geom:bbox":"-78.061748,-2.610042,-75.570734,-0.995007",
     "geom:latitude":-1.720078,
     "geom:longitude":-76.841316,
@@ -150,6 +150,7 @@
         "qs_pg:id":897123,
         "wd:id":"Q1990439"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85670949
     ],
@@ -158,7 +159,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0561eb3857e3d745ee6582d4c4c70bd",
+    "wof:geomhash":"8ed0ee90f110b2745f481445b75ae691",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":421185499,
-    "wof:lastmodified":1690875655,
+    "wof:lastmodified":1695886048,
     "wof:name":"Pastaza",
     "wof:parent_id":85670949,
     "wof:placetype":"county",

--- a/data/421/186/367/421186367.geojson
+++ b/data/421/186/367/421186367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050781,
-    "geom:area_square_m":626854151.679365,
+    "geom:area_square_m":626854236.232265,
     "geom:bbox":"-79.306906,-3.470734,-78.935363,-3.191765",
     "geom:latitude":-3.328213,
     "geom:longitude":-79.117671,
@@ -131,12 +131,13 @@
         "qs_pg:id":1064734,
         "wd:id":"Q2449094"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009478,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"623ada109fe6628dc165cd051038be0f",
+    "wof:geomhash":"209f0d176a75b85c2f0884b314a654cd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421186367,
-    "wof:lastmodified":1690875630,
+    "wof:lastmodified":1695886797,
     "wof:name":"Nab\u00f3n",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/421/188/121/421188121.geojson
+++ b/data/421/188/121/421188121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007446,
-    "geom:area_square_m":91951623.266443,
+    "geom:area_square_m":91951273.131169,
     "geom:bbox":"-78.79282,-3.049675,-78.667952,-2.905188",
     "geom:latitude":-2.983493,
     "geom:longitude":-78.737736,
@@ -125,12 +125,13 @@
         "qs_pg:id":1087913,
         "wd:id":"Q768756"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009535,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4685534d661ce776260e9fb81da5bc0a",
+    "wof:geomhash":"2862ddc58705a01a390dbddc76da9e80",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421188121,
-    "wof:lastmodified":1690875627,
+    "wof:lastmodified":1695886796,
     "wof:name":"Chordeleg",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/421/188/123/421188123.geojson
+++ b/data/421/188/123/421188123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.317462,
-    "geom:area_square_m":3925419958.274101,
+    "geom:area_square_m":3925420117.95484,
     "geom:bbox":"-76.52895,-0.658076,-75.223009,-0.00698",
     "geom:latitude":-0.27534,
     "geom:longitude":-75.87817,
@@ -128,12 +128,13 @@
         "qs_pg:id":1087914,
         "wd:id":"Q1990065"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009535,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0127049e949dd8895fa52f855f035133",
+    "wof:geomhash":"0992ba44c91d9540ab8e64deb6c65251",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":421188123,
-    "wof:lastmodified":1690875628,
+    "wof:lastmodified":1695886797,
     "wof:name":"Cuyabeno",
     "wof:parent_id":85670977,
     "wof:placetype":"county",

--- a/data/421/188/127/421188127.geojson
+++ b/data/421/188/127/421188127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022878,
-    "geom:area_square_m":282604581.32924,
+    "geom:area_square_m":282604581.329167,
     "geom:bbox":"-80.5645249769,-2.72208333,-80.2961659498,-2.46242091475",
     "geom:latitude":-2.55702,
     "geom:longitude":-80.434295,
@@ -109,12 +109,13 @@
         "hasc:id":"EC.GY.PL",
         "qs_pg:id":1087917
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009535,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5723c141cc80e5ebd025e5e17cc4d29c",
+    "wof:geomhash":"1c42441da95b5f84808ffa8cb55897ad",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":421188127,
-    "wof:lastmodified":1582351939,
+    "wof:lastmodified":1695886796,
     "wof:name":"Playas",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/188/131/421188131.geojson
+++ b/data/421/188/131/421188131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.340374,
-    "geom:area_square_m":4208755967.163292,
+    "geom:area_square_m":4208755943.94413,
     "geom:bbox":"-78.944185,-0.595832,-78.160569,0.260146",
     "geom:latitude":-0.100685,
     "geom:longitude":-78.516903,
@@ -135,12 +135,13 @@
         "qs_pg:id":1087919,
         "wd:id":"Q2466472"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009535,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b6515f1fac3c45eff9718be66bbb4e3d",
+    "wof:geomhash":"84ddc20bf9fdceb985450994f7e1d990",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421188131,
-    "wof:lastmodified":1690875627,
+    "wof:lastmodified":1695886797,
     "wof:name":"Quito",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/189/201/421189201.geojson
+++ b/data/421/189/201/421189201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002316,
-    "geom:area_square_m":28617181.310167,
+    "geom:area_square_m":28617281.071255,
     "geom:bbox":"-80.920117,-2.272408,-80.866591,-2.206987",
     "geom:latitude":-2.237776,
     "geom:longitude":-80.890467,
@@ -161,12 +161,13 @@
         "hasc:id":"EC.SE.LL",
         "qs_pg:id":1110294
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009613,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"070592a8a927c373b8d9bac8f1169836",
+    "wof:geomhash":"f74baf48739bcef10c4473811cbcf6dd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":421189201,
-    "wof:lastmodified":1636502157,
+    "wof:lastmodified":1695886047,
     "wof:name":"La Libertad",
     "wof:parent_id":85670979,
     "wof:placetype":"county",

--- a/data/421/189/211/421189211.geojson
+++ b/data/421/189/211/421189211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.248219,
-    "geom:area_square_m":3069147086.083207,
+    "geom:area_square_m":3069146708.495383,
     "geom:bbox":"-80.285016,-0.860691,-79.596514,0.092093",
     "geom:latitude":-0.464049,
     "geom:longitude":-79.955581,
@@ -180,12 +180,13 @@
         "qs_pg:id":1110304,
         "wd:id":"Q1992996"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009614,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"77b5ee56fe3e96b2a3c813fec3f1a970",
+    "wof:geomhash":"2800b24fb131bb5629625bf919066d95",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":421189211,
-    "wof:lastmodified":1690875625,
+    "wof:lastmodified":1695886046,
     "wof:name":"Chone",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/189/213/421189213.geojson
+++ b/data/421/189/213/421189213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023305,
-    "geom:area_square_m":287556852.935947,
+    "geom:area_square_m":287556984.205122,
     "geom:bbox":"-79.644786,-3.811394,-79.368596,-3.667491",
     "geom:latitude":-3.738775,
     "geom:longitude":-79.501059,
@@ -132,12 +132,13 @@
         "qs_pg:id":1110306,
         "wd:id":"Q661446"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009614,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a34c91c86b965900e615547823ef1ef5",
+    "wof:geomhash":"e7079e6683ac1c92223b7deb7082a154",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421189213,
-    "wof:lastmodified":1690875626,
+    "wof:lastmodified":1695886797,
     "wof:name":"Portovelo",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/421/189/215/421189215.geojson
+++ b/data/421/189/215/421189215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.150059,
-    "geom:area_square_m":1855250544.004664,
+    "geom:area_square_m":1855250827.918583,
     "geom:bbox":"-79.715889,-1.330409,-79.077456,-0.53617",
     "geom:latitude":-0.9443,
     "geom:longitude":-79.402838,
@@ -150,12 +150,13 @@
         "qs_pg:id":1110307,
         "wd:id":"Q1990421"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009614,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c978d024eef59a0bfbe8c957d46976ab",
+    "wof:geomhash":"b8d9aaa9fcf7f8fa38e0bdd0f9611b27",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":421189215,
-    "wof:lastmodified":1690875626,
+    "wof:lastmodified":1695886797,
     "wof:name":"Quevedo",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/421/189/217/421189217.geojson
+++ b/data/421/189/217/421189217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031408,
-    "geom:area_square_m":388136541.605758,
+    "geom:area_square_m":388136589.848105,
     "geom:bbox":"-79.892155,-2.154055,-79.639651,-1.865938",
     "geom:latitude":-1.98752,
     "geom:longitude":-79.783814,
@@ -141,12 +141,13 @@
         "qs_pg:id":1110308,
         "wd:id":"Q2051898"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009614,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b8ae493c55032bcbef04145088477428",
+    "wof:geomhash":"f6c2c6c7dc162bec192d401928e07d77",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":421189217,
-    "wof:lastmodified":1690875626,
+    "wof:lastmodified":1695886796,
     "wof:name":"Samborond\u00f3n",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/189/221/421189221.geojson
+++ b/data/421/189/221/421189221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063039,
-    "geom:area_square_m":778311931.599573,
+    "geom:area_square_m":778311870.892594,
     "geom:bbox":"-79.617476,-3.369837,-79.224709,-2.902272",
     "geom:latitude":-3.150514,
     "geom:longitude":-79.3996,
@@ -156,12 +156,13 @@
         "qs_pg:id":1110310,
         "wd:id":"Q2466558"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009614,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a868d5a157fda8eb8dfea0d358c83c75",
+    "wof:geomhash":"09699eaa6196cbf4e32da55e74b9be6a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":421189221,
-    "wof:lastmodified":1690875626,
+    "wof:lastmodified":1695886047,
     "wof:name":"Santa Isabel",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/421/189/223/421189223.geojson
+++ b/data/421/189/223/421189223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072512,
-    "geom:area_square_m":896478639.87871,
+    "geom:area_square_m":896478800.704004,
     "geom:bbox":"-80.561658,-1.198791,-80.008162,-0.927666",
     "geom:latitude":-1.050386,
     "geom:longitude":-80.350236,
@@ -149,12 +149,13 @@
         "qs_pg:id":1110311,
         "wd:id":"Q617905"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009614,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1a94a0cc2e7b43e3e66961bfe44b48d6",
+    "wof:geomhash":"0557592820881779018ba3c41b176c07",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421189223,
-    "wof:lastmodified":1690875626,
+    "wof:lastmodified":1695886047,
     "wof:name":"Portoviejo",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/190/531/421190531.geojson
+++ b/data/421/190/531/421190531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.127213,
-    "geom:area_square_m":1573006280.898485,
+    "geom:area_square_m":1573006685.872203,
     "geom:bbox":"-79.371496,-0.14133,-78.645337,0.330008",
     "geom:latitude":0.048828,
     "geom:longitude":-79.046738,
@@ -91,12 +91,13 @@
         "hasc:id":"EC.PC.SM",
         "qs_pg:id":1119691
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009660,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3e1b91117563999d0340948c90abb974",
+    "wof:geomhash":"0a8be4ad33d206d3b0726e7008236ae6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421190531,
-    "wof:lastmodified":1627522037,
+    "wof:lastmodified":1695886547,
     "wof:name":"San Miguel de los Bancos",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/190/535/421190535.geojson
+++ b/data/421/190/535/421190535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.266989,
-    "geom:area_square_m":3301313067.241577,
+    "geom:area_square_m":3301312521.335155,
     "geom:bbox":"-79.544931,-0.69801,-78.735132,-0.043204",
     "geom:latitude":-0.32731,
     "geom:longitude":-79.168885,
@@ -79,12 +79,13 @@
         "hasc:id":"EC.PI.SD",
         "qs_pg:id":1119694
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009660,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5b4df8e0e616ce4d084e3fd21b68684b",
+    "wof:geomhash":"4c4de7a355e9a0756f9e116a1c8a3bc9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":421190535,
-    "wof:lastmodified":1627522038,
+    "wof:lastmodified":1695886549,
     "wof:name":"Santo Domingo de los Colorados",
     "wof:parent_id":85670983,
     "wof:placetype":"county",

--- a/data/421/191/233/421191233.geojson
+++ b/data/421/191/233/421191233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048087,
-    "geom:area_square_m":592905657.803447,
+    "geom:area_square_m":592905734.498767,
     "geom:bbox":"-80.141746,-4.493179,-79.748356,-4.199184",
     "geom:latitude":-4.328422,
     "geom:longitude":-79.920499,
@@ -134,12 +134,13 @@
         "qs_pg:id":61221,
         "wd:id":"Q1990022"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009685,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e3e9a52879da57cb9d9909e109f68705",
+    "wof:geomhash":"976f258aca8d91b49da2369628439d02",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421191233,
-    "wof:lastmodified":1690875636,
+    "wof:lastmodified":1695886797,
     "wof:name":"Macar\u00e1",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/421/191/235/421191235.geojson
+++ b/data/421/191/235/421191235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098375,
-    "geom:area_square_m":1215651654.227813,
+    "geom:area_square_m":1215651851.311267,
     "geom:bbox":"-78.889027,-2.247118,-78.433579,-1.854923",
     "geom:latitude":-2.039099,
     "geom:longitude":-78.634234,
@@ -135,12 +135,13 @@
         "qs_pg:id":61222,
         "wd:id":"Q2448699"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009685,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"784f8bfe18d04d66a8b7a937437399e4",
+    "wof:geomhash":"4e695ecf25d42f9775c6cf2bb3f4ca5f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421191235,
-    "wof:lastmodified":1690875636,
+    "wof:lastmodified":1695886797,
     "wof:name":"Guamote",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/191/239/421191239.geojson
+++ b/data/421/191/239/421191239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025347,
-    "geom:area_square_m":313138590.412313,
+    "geom:area_square_m":313138623.244965,
     "geom:bbox":"-79.524834,-2.528266,-79.251619,-2.333351",
     "geom:latitude":-2.446259,
     "geom:longitude":-79.381658,
@@ -132,12 +132,13 @@
         "qs_pg:id":61224,
         "wd:id":"Q2466495"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009685,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6c8efe9bc004bb972dc31dd4ef8af42a",
+    "wof:geomhash":"159aea64576280e50ca305c30109f43b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421191239,
-    "wof:lastmodified":1690875637,
+    "wof:lastmodified":1695886797,
     "wof:name":"La Troncal",
     "wof:parent_id":85670909,
     "wof:placetype":"county",

--- a/data/421/191/241/421191241.geojson
+++ b/data/421/191/241/421191241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.093885,
-    "geom:area_square_m":13512637931.8582,
+    "geom:area_square_m":13512636073.881603,
     "geom:bbox":"-78.673632,-3.318882,-76.691148,-1.968072",
     "geom:latitude":-2.536861,
     "geom:longitude":-77.775113,
@@ -150,12 +150,13 @@
         "qs_pg:id":61225,
         "wd:id":"Q1990574"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009685,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3acb35c39dd1745b8208a3aae37576ef",
+    "wof:geomhash":"7f783e230bf72b4783d1f6a56d8e03c9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":421191241,
-    "wof:lastmodified":1690875636,
+    "wof:lastmodified":1695886797,
     "wof:name":"Morona",
     "wof:parent_id":85670935,
     "wof:placetype":"county",

--- a/data/421/191/245/421191245.geojson
+++ b/data/421/191/245/421191245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033316,
-    "geom:area_square_m":411683324.397968,
+    "geom:area_square_m":411683320.463353,
     "geom:bbox":"-79.681264,-2.242652,-79.454965,-1.975797",
     "geom:latitude":-2.115234,
     "geom:longitude":-79.559424,
@@ -159,12 +159,13 @@
         "qs_pg:id":61226,
         "wd:id":"Q1990014"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009685,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"38a55d07a6905f1e87d5b4f2858fa2d5",
+    "wof:geomhash":"4516d8e29b033c1c0046a7a2824c1389",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":421191245,
-    "wof:lastmodified":1690875635,
+    "wof:lastmodified":1695886047,
     "wof:name":"Milagro",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/191/247/421191247.geojson
+++ b/data/421/191/247/421191247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037258,
-    "geom:area_square_m":459924202.44821,
+    "geom:area_square_m":459924093.392057,
     "geom:bbox":"-79.892127,-3.465396,-79.546309,-3.174687",
     "geom:latitude":-3.326392,
     "geom:longitude":-79.731133,
@@ -138,12 +138,13 @@
         "qs_pg:id":61234,
         "wd:id":"Q2448913"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009685,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c4fa87e6927613f0824d8f666fb0d45b",
+    "wof:geomhash":"d5ce89d62806f5488455d00eca0a7a71",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":421191247,
-    "wof:lastmodified":1690875636,
+    "wof:lastmodified":1695886798,
     "wof:name":"Pasaje",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/421/192/947/421192947.geojson
+++ b/data/421/192/947/421192947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022272,
-    "geom:area_square_m":274869815.497676,
+    "geom:area_square_m":274869718.906928,
     "geom:bbox":"-79.8365,-3.652069,-79.599085,-3.458576",
     "geom:latitude":-3.553873,
     "geom:longitude":-79.713621,
@@ -285,12 +285,13 @@
         "qs_pg:id":1184636,
         "wd:id":"Q179577"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009754,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e7c52db9964b1f34e7620cc406e8ac8f",
+    "wof:geomhash":"dae1ea5432b67601fa7a495215f32369",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -300,7 +301,7 @@
         }
     ],
     "wof:id":421192947,
-    "wof:lastmodified":1690875609,
+    "wof:lastmodified":1695886796,
     "wof:name":"Atahualpa",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/421/193/503/421193503.geojson
+++ b/data/421/193/503/421193503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025414,
-    "geom:area_square_m":313881178.759431,
+    "geom:area_square_m":313881118.564076,
     "geom:bbox":"-78.8773,-2.861445,-78.613678,-2.631848",
     "geom:latitude":-2.752623,
     "geom:longitude":-78.735081,
@@ -131,12 +131,13 @@
         "qs_pg:id":911537,
         "wd:id":"Q2449101"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009773,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e188de30c3ba09ea104678cbf92ecf1d",
+    "wof:geomhash":"6e3817e2768ff3de219e7c49514753b6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421193503,
-    "wof:lastmodified":1690875614,
+    "wof:lastmodified":1695886796,
     "wof:name":"Paute",
     "wof:parent_id":85670885,
     "wof:placetype":"county",

--- a/data/421/193/533/421193533.geojson
+++ b/data/421/193/533/421193533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.172017,
-    "geom:area_square_m":2124752613.73339,
+    "geom:area_square_m":2124752862.032568,
     "geom:bbox":"-78.497266,-2.992663,-77.846911,-2.346828",
     "geom:latitude":-2.642226,
     "geom:longitude":-78.105707,
@@ -132,12 +132,13 @@
         "qs_pg:id":911538,
         "wd:id":"Q3656343"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009774,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"217555ff94be2dc37867448f2b92ee32",
+    "wof:geomhash":"6ebf36c07d3104415a4a0d75e505abe9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421193533,
-    "wof:lastmodified":1690875614,
+    "wof:lastmodified":1695886796,
     "wof:name":"Suc\u00faa",
     "wof:parent_id":85670935,
     "wof:placetype":"county",

--- a/data/421/194/443/421194443.geojson
+++ b/data/421/194/443/421194443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067126,
-    "geom:area_square_m":829609961.594609,
+    "geom:area_square_m":829610525.952208,
     "geom:bbox":"-79.021609,-1.946541,-78.677739,-1.645882",
     "geom:latitude":-1.814123,
     "geom:longitude":-78.843443,
@@ -131,12 +131,13 @@
         "qs_pg:id":1110305,
         "wd:id":"Q662249"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009805,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b567b14976bff5599868dc6bfc5cbc0b",
+    "wof:geomhash":"8fecaed9c064ce6293919e57a5f7d758",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421194443,
-    "wof:lastmodified":1690875613,
+    "wof:lastmodified":1695886796,
     "wof:name":"Colta",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/194/445/421194445.geojson
+++ b/data/421/194/445/421194445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103217,
-    "geom:area_square_m":1276001749.308553,
+    "geom:area_square_m":1276001814.61188,
     "geom:bbox":"-80.538536,-1.465455,-79.985456,-1.059071",
     "geom:latitude":-1.22636,
     "geom:longitude":-80.212749,
@@ -144,12 +144,13 @@
         "qs_pg:id":1110312,
         "wd:id":"Q1990587"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009805,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9626045e83fa7dd5e69765014ffdfe4e",
+    "wof:geomhash":"40366f8e3abca487122dd8583ffd577a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":421194445,
-    "wof:lastmodified":1690875614,
+    "wof:lastmodified":1695886046,
     "wof:name":"Santa Ana",
     "wof:parent_id":85670927,
     "wof:placetype":"county",

--- a/data/421/195/039/421195039.geojson
+++ b/data/421/195/039/421195039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049116,
-    "geom:area_square_m":606687077.479541,
+    "geom:area_square_m":606687784.297215,
     "geom:bbox":"-78.917598,-2.840273,-78.566988,-2.423668",
     "geom:latitude":-2.623483,
     "geom:longitude":-78.743281,
@@ -138,12 +138,13 @@
         "qs_pg:id":1184638,
         "wd:id":"Q1990037"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009829,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1e5614be99f8c9602435de2fb07deb4f",
+    "wof:geomhash":"53bed43003f4f99278939596a8663372",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":421195039,
-    "wof:lastmodified":1690875611,
+    "wof:lastmodified":1695886046,
     "wof:name":"Azogues",
     "wof:parent_id":85670909,
     "wof:placetype":"county",

--- a/data/421/195/597/421195597.geojson
+++ b/data/421/195/597/421195597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15121,
-    "geom:area_square_m":1867957655.519806,
+    "geom:area_square_m":1867957178.59167,
     "geom:bbox":"-79.388503,-2.734724,-78.735552,-2.220676",
     "geom:latitude":-2.503737,
     "geom:longitude":-79.051122,
@@ -150,12 +150,13 @@
         "qs_pg:id":115830,
         "wd:id":"Q2466578"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009853,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"acb90cfa65106b76ee500998e11f5ed6",
+    "wof:geomhash":"54130a4ee2fe69d662aa4fa85908c419",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":421195597,
-    "wof:lastmodified":1690875612,
+    "wof:lastmodified":1695886796,
     "wof:name":"Ca\u00f1ar",
     "wof:parent_id":85670909,
     "wof:placetype":"county",

--- a/data/421/195/601/421195601.geojson
+++ b/data/421/195/601/421195601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089637,
-    "geom:area_square_m":1107807110.293318,
+    "geom:area_square_m":1107807317.005054,
     "geom:bbox":"-79.671544,-2.131365,-79.18981,-1.617126",
     "geom:latitude":-1.838314,
     "geom:longitude":-79.430424,
@@ -141,12 +141,13 @@
         "qs_pg:id":115834,
         "wd:id":"Q1990171"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009853,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"adbb3b8733f514a5f0146f0ca76f6c32",
+    "wof:geomhash":"a86ff974cdd6e5c02c8b902e0325fb19",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":421195601,
-    "wof:lastmodified":1690875612,
+    "wof:lastmodified":1695886046,
     "wof:name":"Babahoyo",
     "wof:parent_id":85670923,
     "wof:placetype":"county",

--- a/data/421/195/603/421195603.geojson
+++ b/data/421/195/603/421195603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042764,
-    "geom:area_square_m":527384280.25087,
+    "geom:area_square_m":527384403.568733,
     "geom:bbox":"-80.240759,-4.277251,-79.850864,-4.048298",
     "geom:latitude":-4.166267,
     "geom:longitude":-80.029367,
@@ -141,12 +141,13 @@
         "qs_pg:id":115835,
         "wd:id":"Q1989929"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009853,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e53ba80f640916499f42e2f059541921",
+    "wof:geomhash":"5651c446ee746c6c0700dbea96546a7a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":421195603,
-    "wof:lastmodified":1690875611,
+    "wof:lastmodified":1695886796,
     "wof:name":"Celica",
     "wof:parent_id":85670891,
     "wof:placetype":"county",

--- a/data/421/195/605/421195605.geojson
+++ b/data/421/195/605/421195605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050329,
-    "geom:area_square_m":621024906.359446,
+    "geom:area_square_m":621025016.238801,
     "geom:bbox":"-79.9494,-3.844436,-79.630748,-3.571294",
     "geom:latitude":-3.702263,
     "geom:longitude":-79.779816,
@@ -210,12 +210,13 @@
         "qs_pg:id":115842,
         "wd:id":"Q740750"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009853,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"388c1261803330b8a0686e5c2efa104c",
+    "wof:geomhash":"475eeab1f2afce9feef08f548daa99f9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -225,7 +226,7 @@
         }
     ],
     "wof:id":421195605,
-    "wof:lastmodified":1690875611,
+    "wof:lastmodified":1695886796,
     "wof:name":"Pi\u00f1as",
     "wof:parent_id":85670887,
     "wof:placetype":"county",

--- a/data/421/196/577/421196577.geojson
+++ b/data/421/196/577/421196577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133616,
-    "geom:area_square_m":1650867534.169473,
+    "geom:area_square_m":1650866406.190634,
     "geom:bbox":"-79.074275,-2.555529,-78.462874,-2.081529",
     "geom:latitude":-2.291474,
     "geom:longitude":-78.74029,
@@ -141,12 +141,13 @@
         "qs_pg:id":1205490,
         "wd:id":"Q2448841"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009886,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"be9f898a842edc39ba48ae2bcca84a18",
+    "wof:geomhash":"5ccde2936c48b8e38c2a7c51cea888d2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":421196577,
-    "wof:lastmodified":1690875635,
+    "wof:lastmodified":1695886798,
     "wof:name":"Alaus\u00ed",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/197/049/421197049.geojson
+++ b/data/421/197/049/421197049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097583,
-    "geom:area_square_m":1206627399.402712,
+    "geom:area_square_m":1206627292.474587,
     "geom:bbox":"-78.313287,-0.190591,-77.840108,0.187295",
     "geom:latitude":-0.002503,
     "geom:longitude":-78.071374,
@@ -189,12 +189,13 @@
         "qs_pg:id":1289870,
         "wd:id":"Q1990489"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009901,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b7825dddad576b8574cfb33d30e37b5",
+    "wof:geomhash":"585c33cba47fbf8b79ada5550110a513",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -204,7 +205,7 @@
         }
     ],
     "wof:id":421197049,
-    "wof:lastmodified":1690875637,
+    "wof:lastmodified":1695886047,
     "wof:name":"Cayambe",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/197/133/421197133.geojson
+++ b/data/421/197/133/421197133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011813,
-    "geom:area_square_m":145979247.662488,
+    "geom:area_square_m":145979469.677362,
     "geom:bbox":"-80.113314,-2.083088,-79.989976,-1.875212",
     "geom:latitude":-1.970794,
     "geom:longitude":-80.055028,
@@ -129,12 +129,13 @@
         "qs_pg:id":1313099,
         "wd:id":"Q2466465"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009903,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6025009b2df4e30453f6dca858ac39d2",
+    "wof:geomhash":"c2c985d1a65dbe740dce483ad08eeb7c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421197133,
-    "wof:lastmodified":1690875637,
+    "wof:lastmodified":1695886798,
     "wof:name":"Nobol",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/197/239/421197239.geojson
+++ b/data/421/197/239/421197239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033316,
-    "geom:area_square_m":411936253.099316,
+    "geom:area_square_m":411936271.6357,
     "geom:bbox":"-77.913348,0.423538,-77.643335,0.707491",
     "geom:latitude":0.563316,
     "geom:longitude":-77.799848,
@@ -131,12 +131,13 @@
         "qs_pg:id":61229,
         "wd:id":"Q2448812"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459009907,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"940349d6039a2279e1feae4c4bf156db",
+    "wof:geomhash":"41c754f64387a80146b0064c823c969a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421197239,
-    "wof:lastmodified":1690875638,
+    "wof:lastmodified":1695886798,
     "wof:name":"Mont\u00fafar",
     "wof:parent_id":85670967,
     "wof:placetype":"county",

--- a/data/421/201/111/421201111.geojson
+++ b/data/421/201/111/421201111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037592,
-    "geom:area_square_m":464576098.701643,
+    "geom:area_square_m":464576136.589427,
     "geom:bbox":"-80.065689,-2.062027,-79.832831,-1.772093",
     "geom:latitude":-1.895544,
     "geom:longitude":-79.943608,
@@ -132,12 +132,13 @@
         "qs_pg:id":911528,
         "wd:id":"Q1990162"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459010051,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0f7d0b50db827a92812f262ab4a93dad",
+    "wof:geomhash":"6cb640a920cc2fce5aae31d1c0df2718",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421201111,
-    "wof:lastmodified":1690875641,
+    "wof:lastmodified":1695886798,
     "wof:name":"Daule",
     "wof:parent_id":85670917,
     "wof:placetype":"county",

--- a/data/421/201/227/421201227.geojson
+++ b/data/421/201/227/421201227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013024,
-    "geom:area_square_m":160973337.915975,
+    "geom:area_square_m":160973276.19485,
     "geom:bbox":"-78.631701,-1.806124,-78.425235,-1.677313",
     "geom:latitude":-1.755317,
     "geom:longitude":-78.534856,
@@ -138,12 +138,13 @@
         "qs_pg:id":772744,
         "wd:id":"Q2448802"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459010066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2fb7399780520c8486dc38e480b8fcb6",
+    "wof:geomhash":"1a84cb720302374cdabdc165fbaaada2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":421201227,
-    "wof:lastmodified":1690875640,
+    "wof:lastmodified":1695886798,
     "wof:name":"Chambo",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/201/625/421201625.geojson
+++ b/data/421/201/625/421201625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037324,
-    "geom:area_square_m":461352268.590384,
+    "geom:area_square_m":461352209.237016,
     "geom:bbox":"-78.846116,-1.648144,-78.510247,-1.42681",
     "geom:latitude":-1.540758,
     "geom:longitude":-78.660265,
@@ -279,12 +279,13 @@
         "qs_pg:id":1264176,
         "wd:id":"Q2448847"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459010079,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7970288b6d5fa291e28c4200f959f5bb",
+    "wof:geomhash":"3569af91d19582faffdd40d7f602ccc5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -294,7 +295,7 @@
         }
     ],
     "wof:id":421201625,
-    "wof:lastmodified":1690875642,
+    "wof:lastmodified":1695886798,
     "wof:name":"Guano",
     "wof:parent_id":85670931,
     "wof:placetype":"county",

--- a/data/421/201/631/421201631.geojson
+++ b/data/421/201/631/421201631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116004,
-    "geom:area_square_m":1433796853.851122,
+    "geom:area_square_m":1433796619.250188,
     "geom:bbox":"-78.374897,-1.877692,-77.842087,-1.444084",
     "geom:latitude":-1.66775,
     "geom:longitude":-78.110465,
@@ -132,12 +132,13 @@
         "qs_pg:id":1264190,
         "wd:id":"Q1990533"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459010079,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"31ba24cd4009306e776c68f79512af28",
+    "wof:geomhash":"1f7ea89a0fb880d9a8555e3538484679",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421201631,
-    "wof:lastmodified":1690875642,
+    "wof:lastmodified":1695886798,
     "wof:name":"Palora",
     "wof:parent_id":85670935,
     "wof:placetype":"county",

--- a/data/421/203/379/421203379.geojson
+++ b/data/421/203/379/421203379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048033,
-    "geom:area_square_m":593892330.552652,
+    "geom:area_square_m":593892525.501381,
     "geom:bbox":"-78.452458,0.475583,-77.984919,0.961122",
     "geom:latitude":0.720742,
     "geom:longitude":-78.19392,
@@ -157,12 +157,13 @@
         "qs_pg:id":61228,
         "wd:id":"Q2448888"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459010149,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6c6b626b99bc3a2fb77b06bb42e0714d",
+    "wof:geomhash":"c16be3ae7d997155df8099cedf899c34",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":421203379,
-    "wof:lastmodified":1690875620,
+    "wof:lastmodified":1695886046,
     "wof:name":"Mira",
     "wof:parent_id":85670967,
     "wof:placetype":"county",

--- a/data/421/203/481/421203481.geojson
+++ b/data/421/203/481/421203481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005923,
-    "geom:area_square_m":73176036.42538,
+    "geom:area_square_m":73176061.160404,
     "geom:bbox":"-81.010445,-2.337083,-80.852699,-2.180417",
     "geom:latitude":-2.257744,
     "geom:longitude":-80.917971,
@@ -217,12 +217,13 @@
         "qs_pg:id":978468,
         "wd:id":"Q1992844"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459010154,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"64f7294949b26126f8644e28c10db5c8",
+    "wof:geomhash":"e734d4a24345e0dce4bb39a660c2cd08",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -232,7 +233,7 @@
         }
     ],
     "wof:id":421203481,
-    "wof:lastmodified":1690875620,
+    "wof:lastmodified":1695886046,
     "wof:name":"Salinas",
     "wof:parent_id":85670979,
     "wof:placetype":"county",

--- a/data/421/203/597/421203597.geojson
+++ b/data/421/203/597/421203597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051406,
-    "geom:area_square_m":635637220.404419,
+    "geom:area_square_m":635636883.230173,
     "geom:bbox":"-79.176067,0.001178,-78.929185,0.320431",
     "geom:latitude":0.150028,
     "geom:longitude":-79.05622,
@@ -147,12 +147,13 @@
         "qs_pg:id":233710,
         "wd:id":"Q1992916"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459010157,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ee716e1af1dd15e9ce9e8129d7dc98d2",
+    "wof:geomhash":"e42a6161d2637bc7237dbcbf75821da2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":421203597,
-    "wof:lastmodified":1690875620,
+    "wof:lastmodified":1695886796,
     "wof:name":"Pedro Vicente Maldonado",
     "wof:parent_id":85670945,
     "wof:placetype":"county",

--- a/data/421/204/303/421204303.geojson
+++ b/data/421/204/303/421204303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153797,
-    "geom:area_square_m":1901485949.375235,
+    "geom:area_square_m":1901486722.728969,
     "geom:bbox":"-78.545816,0.560062,-77.534288,1.195309",
     "geom:latitude":0.892113,
     "geom:longitude":-78.120854,
@@ -261,12 +261,13 @@
         "qs_pg:id":239109,
         "wd:id":"Q752113"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1459010180,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9485661931caf6a56ca21f03a51b4b7c",
+    "wof:geomhash":"4a74c92b2d2e5ecfcbe602e4dcea8500",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -276,7 +277,7 @@
         }
     ],
     "wof:id":421204303,
-    "wof:lastmodified":1690875619,
+    "wof:lastmodified":1695886796,
     "wof:name":"Tulc\u00e1n",
     "wof:parent_id":85670967,
     "wof:placetype":"county",

--- a/data/856/322/61/85632261.geojson
+++ b/data/856/322/61/85632261.geojson
@@ -1226,6 +1226,7 @@
         "hasc:id":"EC",
         "icao:code":"HC",
         "ioc:id":"ECU",
+        "iso:code":"EC",
         "itu:id":"EQA",
         "loc:id":"n79068415",
         "m49:code":"218",
@@ -1240,6 +1241,7 @@
         "wk:page":"Ecuador",
         "wmo:id":"EQ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:country_alpha3":"ECU",
     "wof:geom_alt":[
@@ -1263,7 +1265,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1694639546,
+    "wof:lastmodified":1695881204,
     "wof:name":"Ecuador",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/708/85/85670885.geojson
+++ b/data/856/708/85/85670885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.650931,
-    "geom:area_square_m":8037686835.570027,
+    "geom:area_square_m":8037687226.143045,
     "geom:bbox":"-79.758123,-3.623347,-78.420305,-2.549815",
     "geom:latitude":-3.014888,
     "geom:longitude":-79.146551,
@@ -323,17 +323,19 @@
         "gn:id":3660431,
         "gp:id":2345203,
         "hasc:id":"EC.AZ",
+        "iso:code":"EC-A",
         "iso:id":"EC-A",
         "qs_pg:id":423732,
         "unlc:id":"EC-A",
         "wd:id":"Q220451",
         "wk:page":"Azuay Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"36a7232c09253daf07504686911a81ea",
+    "wof:geomhash":"2d93e0344198bbaae6aad8547d0d5b14",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -350,7 +352,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875576,
+    "wof:lastmodified":1695884365,
     "wof:name":"Azuay",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/708/87/85670887.geojson
+++ b/data/856/708/87/85670887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.472968,
-    "geom:area_square_m":5837339833.575554,
+    "geom:area_square_m":5837340012.873726,
     "geom:bbox":"-80.307653,-3.892187,-79.36281,-3.040236",
     "geom:latitude":-3.509117,
     "geom:longitude":-79.826015,
@@ -308,17 +308,19 @@
         "gn:id":3658195,
         "gp:id":2345209,
         "hasc:id":"EC.EO",
+        "iso:code":"EC-O",
         "iso:id":"EC-O",
         "qs_pg:id":235588,
         "unlc:id":"EC-O",
         "wd:id":"Q466019",
         "wk:page":"El Oro Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"75a717cc7d809a54eab022d0c3905495",
+    "wof:geomhash":"66fd7e8bacce203c5ce5c3123b73d9d6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -335,7 +337,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875574,
+    "wof:lastmodified":1695884365,
     "wof:name":"El Oro",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/708/91/85670891.geojson
+++ b/data/856/708/91/85670891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.90362,
-    "geom:area_square_m":11144870152.864212,
+    "geom:area_square_m":11144870539.916595,
     "geom:bbox":"-80.485956,-4.744841,-79.096636,-3.32675",
     "geom:latitude":-4.089208,
     "geom:longitude":-79.655417,
@@ -319,17 +319,19 @@
         "gn:id":3654665,
         "gp:id":2345213,
         "hasc:id":"EC.LJ",
+        "iso:code":"EC-L",
         "iso:id":"EC-L",
         "qs_pg:id":423742,
         "unlc:id":"EC-L",
         "wd:id":"Q504238",
         "wk:page":"Loja Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bbc5ff06979f25ce2bbca3d0d4b34b50",
+    "wof:geomhash":"976458d3f6eeb4c96aa13b6db80ba53d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -346,7 +348,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875575,
+    "wof:lastmodified":1695884920,
     "wof:name":"Loja",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/708/95/85670895.geojson
+++ b/data/856/708/95/85670895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.86221,
-    "geom:area_square_m":10632864757.117531,
+    "geom:area_square_m":10632864926.947292,
     "geom:bbox":"-79.429451,-5.013975,-78.36667,-3.331658",
     "geom:latitude":-4.170697,
     "geom:longitude":-78.902971,
@@ -309,17 +309,19 @@
         "gn:id":3649953,
         "gp:id":2345221,
         "hasc:id":"EC.ZC",
+        "iso:code":"EC-Z",
         "iso:id":"EC-Z",
         "qs_pg:id":219550,
         "unlc:id":"EC-Z",
         "wd:id":"Q744670",
         "wk:page":"Zamora-Chinchipe Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e48889705e59b538e59e8724a03adfc0",
+    "wof:geomhash":"7a4c663ebe7d363cb7743e1fba7128cf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -336,7 +338,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875574,
+    "wof:lastmodified":1695884920,
     "wof:name":"Zamora Chinchipe",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/708/99/85670899.geojson
+++ b/data/856/708/99/85670899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.653128,
-    "geom:area_square_m":8075535390.346149,
+    "geom:area_square_m":8075535492.221111,
     "geom:bbox":"-91.662941,-1.407111,-89.240471,0.643528",
     "geom:latitude":-0.547437,
     "geom:longitude":-90.898035,
@@ -319,17 +319,19 @@
         "gn:id":3657879,
         "gp:id":2345202,
         "hasc:id":"EC.GA",
+        "iso:code":"EC-W",
         "iso:id":"EC-W",
         "qs_pg:id":913548,
         "unlc:id":"EC-W",
         "wd:id":"Q475038",
         "wk:page":"Gal\u00e1pagos Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ab1c926dbe53003424000646f2f72e70",
+    "wof:geomhash":"7fb69f163503ba083a1006940bbccc83",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -346,7 +348,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875575,
+    "wof:lastmodified":1695884365,
     "wof:name":"Gal\u00e1pagos",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/05/85670905.geojson
+++ b/data/856/709/05/85670905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.319096,
-    "geom:area_square_m":3944119380.381306,
+    "geom:area_square_m":3944119186.590034,
     "geom:bbox":"-79.390141,-2.196502,-78.838707,-1.146593",
     "geom:latitude":-1.591461,
     "geom:longitude":-79.102997,
@@ -317,16 +317,18 @@
         "gn:id":3660130,
         "gp:id":2345204,
         "hasc:id":"EC.BO",
+        "iso:code":"EC-B",
         "iso:id":"EC-B",
         "qs_pg:id":1285168,
         "wd:id":"Q261165",
         "wk:page":"Bol\u00edvar Province (Ecuador)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"af460cf3e180b2c49e2dab1b2f310ec0",
+    "wof:geomhash":"8ae8ba7e5c6d66d0634041d888f4108f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -343,7 +345,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875577,
+    "wof:lastmodified":1695884921,
     "wof:name":"Bolivar",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/09/85670909.geojson
+++ b/data/856/709/09/85670909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.270686,
-    "geom:area_square_m":3343807609.62482,
+    "geom:area_square_m":3343807971.667336,
     "geom:bbox":"-79.524834,-2.840273,-78.566988,-2.220676",
     "geom:latitude":-2.530704,
     "geom:longitude":-79.025565,
@@ -318,17 +318,19 @@
         "gn:id":3659849,
         "gp:id":2345205,
         "hasc:id":"EC.CN",
+        "iso:code":"EC-F",
         "iso:id":"EC-F",
         "qs_pg:id":423737,
         "unlc:id":"EC-F",
         "wd:id":"Q335471",
         "wk:page":"Ca\u00f1ar Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b4cb9ee1cbbb06d478ae6291ea6025bf",
+    "wof:geomhash":"5b90c63498a6b4b768b0d81f4840c00b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -345,7 +347,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875579,
+    "wof:lastmodified":1695884366,
     "wof:name":"Ca\u00f1ar",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/15/85670915.geojson
+++ b/data/856/709/15/85670915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.488891,
-    "geom:area_square_m":6044517365.902821,
+    "geom:area_square_m":6044517502.330825,
     "geom:bbox":"-79.335379,-1.215581,-78.384366,-0.331313",
     "geom:latitude":-0.861913,
     "geom:longitude":-78.855614,
@@ -308,17 +308,19 @@
         "gn:id":3658766,
         "gp:id":2345208,
         "hasc:id":"EC.CT",
+        "iso:code":"EC-X",
         "iso:id":"EC-X",
         "qs_pg:id":894876,
         "unlc:id":"EC-X",
         "wd:id":"Q241140",
         "wk:page":"Cotopaxi Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"770234f6f43f9a6d197d78d05a05d693",
+    "wof:geomhash":"174aa90b7c027b8b400df96d33635641",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -335,7 +337,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875582,
+    "wof:lastmodified":1695884921,
     "wof:name":"Cotopaxi",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/17/85670917.geojson
+++ b/data/856/709/17/85670917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.287404,
-    "geom:area_square_m":15907609888.206226,
+    "geom:area_square_m":15907608617.197262,
     "geom:bbox":"-80.564525,-3.062599,-79.111589,-0.830383",
     "geom:latitude":-2.109518,
     "geom:longitude":-79.88035,
@@ -341,17 +341,19 @@
         "gn:id":3657505,
         "gp:id":2345211,
         "hasc:id":"EC.GY",
+        "iso:code":"EC-G",
         "iso:id":"EC-G",
         "qs_pg:id":890049,
         "unlc:id":"EC-G",
         "wd:id":"Q335464",
         "wk:page":"Guayas Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"842825efffe480605a3fd72fdeed8a65",
+    "wof:geomhash":"334081dad1426c5714ec26a06baf3b3a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -368,7 +370,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875578,
+    "wof:lastmodified":1695884365,
     "wof:name":"Guayas",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/23/85670923.geojson
+++ b/data/856/709/23/85670923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.587659,
-    "geom:area_square_m":7264348318.355412,
+    "geom:area_square_m":7264349465.424256,
     "geom:bbox":"-79.872545,-2.131365,-79.077456,-0.532686",
     "geom:latitude":-1.344793,
     "geom:longitude":-79.487591,
@@ -321,16 +321,18 @@
         "gn:id":3654592,
         "gp:id":2345214,
         "hasc:id":"EC.LR",
+        "iso:code":"EC-R",
         "iso:id":"EC-R",
         "qs_pg:id":423743,
         "wd:id":"Q504260",
         "wk:page":"Los R\u00edos Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c1cf979e65ec6068e0379570cc7fb693",
+    "wof:geomhash":"eaa0ebf62375975835218f015434ae50",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -347,7 +349,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875582,
+    "wof:lastmodified":1695884921,
     "wof:name":"Los Rios",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/27/85670927.geojson
+++ b/data/856/709/27/85670927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.575702,
-    "geom:area_square_m":19481392515.274601,
+    "geom:area_square_m":19481392844.975788,
     "geom:bbox":"-81.082085,-1.943955,-79.398944,0.370111",
     "geom:latitude":-0.750991,
     "geom:longitude":-80.135315,
@@ -319,16 +319,18 @@
         "gn:id":3654451,
         "gp:id":2345215,
         "hasc:id":"EC.MN",
+        "iso:code":"EC-M",
         "iso:id":"EC-M",
         "qs_pg:id":318436,
         "wd:id":"Q504666",
         "wk:page":"Manab\u00ed Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3ba6fa1376f8d22c9e3ae26eb484c780",
+    "wof:geomhash":"3f675944b1b07745834a1f204ee7c78c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -345,7 +347,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875578,
+    "wof:lastmodified":1695884366,
     "wof:name":"Manabi",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/31/85670931.geojson
+++ b/data/856/709/31/85670931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.526146,
-    "geom:area_square_m":6501982446.18535,
+    "geom:area_square_m":6501982152.580894,
     "geom:bbox":"-79.1396,-2.555529,-78.357451,-1.42681",
     "geom:latitude":-1.969092,
     "geom:longitude":-78.714846,
@@ -346,16 +346,18 @@
         "gn:id":3659237,
         "gp:id":2345207,
         "hasc:id":"EC.CB",
+        "iso:code":"EC-H",
         "iso:id":"EC-H",
         "qs_pg:id":219546,
         "wd:id":"Q238492",
         "wk:page":"Chimborazo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"224aa00890751d769a540dd8e43bbc20",
+    "wof:geomhash":"919d41cd228545a28e107ce3006be723",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -372,7 +374,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875579,
+    "wof:lastmodified":1695884921,
     "wof:name":"Chimborazo",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/35/85670935.geojson
+++ b/data/856/709/35/85670935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.958656,
-    "geom:area_square_m":24194086271.230896,
+    "geom:area_square_m":24194083709.377357,
     "geom:bbox":"-78.949525,-3.584404,-76.691148,-1.444084",
     "geom:latitude":-2.562339,
     "geom:longitude":-78.003384,
@@ -318,17 +318,19 @@
         "gn:id":3654005,
         "gp:id":2345216,
         "hasc:id":"EC.MS",
+        "iso:code":"EC-S",
         "iso:id":"EC-S",
         "qs_pg:id":235590,
         "unlc:id":"EC-S",
         "wd:id":"Q549522",
         "wk:page":"Morona-Santiago Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bdedb8937d501ba793b292f1dca8428b",
+    "wof:geomhash":"b7956c819149f2e255d06f5f303e5942",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -345,7 +347,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875576,
+    "wof:lastmodified":1695884366,
     "wof:name":"Morona Santiago",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/41/85670941.geojson
+++ b/data/856/709/41/85670941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.730634,
-    "geom:area_square_m":21397381441.48827,
+    "geom:area_square_m":21397379898.258705,
     "geom:bbox":"-77.627997,-1.563567,-75.188794,-0.03698",
     "geom:latitude":-0.778256,
     "geom:longitude":-76.372775,
@@ -318,17 +318,19 @@
         "gn:id":3830306,
         "gp:id":20070099,
         "hasc:id":"EC.OR",
+        "iso:code":"EC-D",
         "iso:id":"EC-D",
         "qs_pg:id":424304,
         "unlc:id":"EC-D",
         "wd:id":"Q499475",
         "wk:page":"Orellana Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"820d8e9a3dbafe8af7d47cd5635e5ad3",
+    "wof:geomhash":"e085dec48e3d48fc237d0d0dc5cae985",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -345,7 +347,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875581,
+    "wof:lastmodified":1695884921,
     "wof:name":"Orellana",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/45/85670945.geojson
+++ b/data/856/709/45/85670945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.774803,
-    "geom:area_square_m":9580484332.846516,
+    "geom:area_square_m":9580484647.636457,
     "geom:bbox":"-79.371496,-0.719393,-77.840108,0.330008",
     "geom:latitude":-0.106436,
     "geom:longitude":-78.591388,
@@ -320,17 +320,19 @@
         "gn:id":3653224,
         "gp:id":2345219,
         "hasc:id":"EC.PC",
+        "iso:code":"EC-P",
         "iso:id":"EC-P",
         "qs_pg:id":219549,
         "unlc:id":"EC-P",
         "wd:id":"Q272586",
         "wk:page":"Pichincha Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a3e96e8b0230df06894e2772617c0523",
+    "wof:geomhash":"9c9bbcfa4840ccc51862025f8cb36a04",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -347,7 +349,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875578,
+    "wof:lastmodified":1695884921,
     "wof:name":"Pichincha",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/49/85670949.geojson
+++ b/data/856/709/49/85670949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.415526,
-    "geom:area_square_m":29854576541.985523,
+    "geom:area_square_m":29854576541.98465,
     "geom:bbox":"-78.16985,-2.610042,-75.570734,-0.995007",
     "geom:latitude":-1.709596,
     "geom:longitude":-76.874378,
@@ -314,12 +314,14 @@
         "gn:id":3653392,
         "gp:id":2345218,
         "hasc:id":"EC.PA",
+        "iso:code":"EC-Y",
         "iso:id":"EC-Y",
         "qs_pg:id":219548,
         "unlc:id":"EC-Y",
         "wd:id":"Q214814",
         "wk:page":"Pastaza Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421185499
     ],
@@ -327,7 +329,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"539b240caaf4d1c1f0aa27e6d16875e6",
+    "wof:geomhash":"0970565488a30b36697f68afc7a9f6bd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -344,7 +346,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875583,
+    "wof:lastmodified":1695884921,
     "wof:name":"Pastaza",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/53/85670953.geojson
+++ b/data/856/709/53/85670953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.014107,
-    "geom:area_square_m":12538618095.528502,
+    "geom:area_square_m":12538619892.962799,
     "geom:bbox":"-78.42271,-1.243855,-77.031939,0.037147",
     "geom:latitude":-0.654198,
     "geom:longitude":-77.819888,
@@ -304,16 +304,18 @@
         "gn:id":3650445,
         "gp:id":2345220,
         "hasc:id":"EC.NA",
+        "iso:code":"EC-N",
         "iso:id":"EC-N",
         "qs_pg:id":1168645,
         "wd:id":"Q504252",
         "wk:page":"Tungurahua Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ffbc27ef2eacfe3ac43fa27f545a3be8",
+    "wof:geomhash":"0279f992e38359b1b9212fa0e58a4afa",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -330,7 +332,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875579,
+    "wof:lastmodified":1695884921,
     "wof:name":"Napo",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/59/85670959.geojson
+++ b/data/856/709/59/85670959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.274759,
-    "geom:area_square_m":3396579112.146156,
+    "geom:area_square_m":3396578521.350764,
     "geom:bbox":"-78.936449,-1.519016,-78.109639,-0.979785",
     "geom:latitude":-1.291657,
     "geom:longitude":-78.505371,
@@ -307,16 +307,18 @@
         "gn:id":3653890,
         "gp:id":2345217,
         "hasc:id":"EC.TU",
+        "iso:code":"EC-T",
         "iso:id":"EC-T",
         "qs_pg:id":219547,
         "wd:id":"Q211900",
         "wk:page":"Napo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1e24c480f9c2c70d2a6814abbfd45d55",
+    "wof:geomhash":"ca148ccf397277612e5dc0ab2cae367f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -333,7 +335,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875576,
+    "wof:lastmodified":1695884921,
     "wof:name":"Tungurahua",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/63/85670963.geojson
+++ b/data/856/709/63/85670963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.249342,
-    "geom:area_square_m":15446990481.14308,
+    "geom:area_square_m":15446991837.460068,
     "geom:bbox":"-80.106667,0.068936,-78.425919,1.454337",
     "geom:latitude":0.710412,
     "geom:longitude":-79.216292,
@@ -312,17 +312,19 @@
         "gn:id":3657986,
         "gp:id":2345210,
         "hasc:id":"EC.ES",
+        "iso:code":"EC-E",
         "iso:id":"EC-E",
         "qs_pg:id":235589,
         "unlc:id":"EC-E",
         "wd:id":"Q335526",
         "wk:page":"Esmeraldas Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9475ec8c1f3956dd699ccdebb46318fb",
+    "wof:geomhash":"99ad2c809994ffa499e64c8051b9c71f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -339,7 +341,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875580,
+    "wof:lastmodified":1695884366,
     "wof:name":"Esmeraldas",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/67/85670967.geojson
+++ b/data/856/709/67/85670967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.310942,
-    "geom:area_square_m":3844490859.836877,
+    "geom:area_square_m":3844491568.269318,
     "geom:bbox":"-78.545816,0.355629,-77.534288,1.195309",
     "geom:latitude":0.762905,
     "geom:longitude":-78.064741,
@@ -311,17 +311,19 @@
         "gn:id":3659718,
         "gp:id":2345206,
         "hasc:id":"EC.CR",
+        "iso:code":"EC-C",
         "iso:id":"EC-C",
         "qs_pg:id":423738,
         "unlc:id":"EC-C",
         "wd:id":"Q321729",
         "wk:page":"Carchi Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f985bf8c6d00ade7baceff93406e5f24",
+    "wof:geomhash":"c9842c3575dcd39924b675a0e9747f33",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -338,7 +340,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875577,
+    "wof:lastmodified":1695884366,
     "wof:name":"Carchi",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/71/85670971.geojson
+++ b/data/856/709/71/85670971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.389155,
-    "geom:area_square_m":4811842390.569378,
+    "geom:area_square_m":4811841807.097549,
     "geom:bbox":"-79.273112,0.123108,-77.784663,0.877563",
     "geom:latitude":0.40531,
     "geom:longitude":-78.357075,
@@ -308,17 +308,19 @@
         "gn:id":3655635,
         "gp:id":2345212,
         "hasc:id":"EC.IM",
+        "iso:code":"EC-I",
         "iso:id":"EC-I",
         "qs_pg:id":890050,
         "unlc:id":"EC-I",
         "wd:id":"Q321863",
         "wk:page":"Imbabura Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"20e879287acfa0048abd2f376728cec5",
+    "wof:geomhash":"16ef3a134ef02818f76ea254dbff19e5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -335,7 +337,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875582,
+    "wof:lastmodified":1695884366,
     "wof:name":"Imbabura",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/77/85670977.geojson
+++ b/data/856/709/77/85670977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.446626,
-    "geom:area_square_m":17887641851.042332,
+    "geom:area_square_m":17887641636.646732,
     "geom:bbox":"-77.969155,-0.658076,-75.223009,0.662214",
     "geom:latitude":-0.017923,
     "geom:longitude":-76.576108,
@@ -320,16 +320,18 @@
         "gn:id":3830305,
         "gp:id":2345222,
         "hasc:id":"EC.SU",
+        "iso:code":"EC-U",
         "iso:id":"EC-U",
         "qs_pg:id":423744,
         "wd:id":"Q499456",
         "wk:page":"Sucumb\u00edos Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1d6bccd81f32f1c1034ac5751c611b2e",
+    "wof:geomhash":"8022fc49c4f0cd54ee8b8f04f7a20ec6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -346,7 +348,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875581,
+    "wof:lastmodified":1695884921,
     "wof:name":"Sucumbios",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/79/85670979.geojson
+++ b/data/856/709/79/85670979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307862,
-    "geom:area_square_m":3804117243.784019,
+    "geom:area_square_m":3804117243.783338,
     "geom:bbox":"-81.010445,-2.503434,-80.225604,-1.652626",
     "geom:latitude":-2.132068,
     "geom:longitude":-80.576171,
@@ -311,12 +311,14 @@
         "gn:id":7062138,
         "gp:id":56189815,
         "hasc:id":"EC.SE",
+        "iso:code":"EC-SE",
         "iso:id":"EC-SE",
         "qs_pg:id":224045,
         "unlc:id":"EC-SE",
         "wd:id":"Q1124125",
         "wk:page":"Santa Elena Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1108572401
     ],
@@ -324,7 +326,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"456c5e2662e144d17fe23193a6e3abcd",
+    "wof:geomhash":"d0457e467d7801eef0853465582a98da",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -341,7 +343,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875580,
+    "wof:lastmodified":1695884921,
     "wof:name":"Santa Elena",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/856/709/83/85670983.geojson
+++ b/data/856/709/83/85670983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.337031,
-    "geom:area_square_m":4167386877.400862,
+    "geom:area_square_m":4167386280.22927,
     "geom:bbox":"-79.623981,-0.69801,-78.735132,0.12596",
     "geom:latitude":-0.262006,
     "geom:longitude":-79.218565,
@@ -277,17 +277,19 @@
         "gn:id":7062136,
         "gp:id":56189814,
         "hasc:id":"EC.SD",
+        "iso:code":"EC-SD",
         "iso:id":"EC-SD",
         "qs_pg:id":232142,
         "unlc:id":"EC-SD",
         "wd:id":"Q1123208",
         "wk:page":"Santo Domingo de los Ts\u00e1chilas Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EC",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6a018342c27fd14d23989d7ee316742f",
+    "wof:geomhash":"87911777ec42e3e6e02ac56619e4a296",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -304,7 +306,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690875581,
+    "wof:lastmodified":1695884366,
     "wof:name":"Santo Domingo de los Ts\u00e1chilas",
     "wof:parent_id":85632261,
     "wof:placetype":"region",

--- a/data/890/451/517/890451517.geojson
+++ b/data/890/451/517/890451517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011426,
-    "geom:area_square_m":141074476.495096,
+    "geom:area_square_m":141074137.821958,
     "geom:bbox":"-79.328973,-3.227928,-79.209141,-3.049839",
     "geom:latitude":-3.130096,
     "geom:longitude":-79.267712,
@@ -153,12 +153,13 @@
         "qs_pg:id":108045,
         "wd:id":"Q2449055"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EC",
     "wof:created":1469052783,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"06e9261d24762530b11ea23d7f2f73d0",
+    "wof:geomhash":"5687f3cad70169bbfac8d0488af9f7e3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":890451517,
-    "wof:lastmodified":1690875657,
+    "wof:lastmodified":1695886049,
     "wof:name":"San Fernando",
     "wof:parent_id":85670885,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.